### PR TITLE
Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ['3.12', '3.13']


### PR DESCRIPTION
Potential fix for [https://github.com/stuartparmenter/media-proxy/security/code-scanning/5](https://github.com/stuartparmenter/media-proxy/security/code-scanning/5)

To fix the issue, you should add a `permissions:` block specifying the least privilege required by the workflow for the actions it performs. As the workflow only checks out code, installs dependencies, and runs tests—it does not make changes to the repository, open PRs, write to issues, etc.—it only needs read access to repository contents.  
The best way to do this is to add `permissions: contents: read` at the job level under `test:` (after `runs-on:`), or at the root level so it applies to all jobs (since there's only one job).  
For clarity and specificity, add the block under the `test:` job immediately after `runs-on: ubuntu-latest`.

No methods or imports are needed—just YAML key addition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
