### PR TITLE
Document current behavior and tighten code comments

### DIFF
--- a/.github/workflows/sync-addon.yml
+++ b/.github/workflows/sync-addon.yml
@@ -89,7 +89,7 @@ jobs:
           python3 tests/smoke.py --binary "$BIN_DIR/media-proxy"
           if [ "$REUSE" != true ]; then
             tar -czf "dist/$ASSET" -C "$BIN_DIR" media-proxy ddp-view \
-              -C "$GITHUB_WORKSPACE" LICENSE THIRD_PARTY_LICENSES.md README.md
+              -C "$GITHUB_WORKSPACE" LICENSE THIRD_PARTY_LICENSES.md README.md docs
             (cd dist && sha256sum "$ASSET" > "$ASSET.sha256")
           fi
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 rust-version = "1.98.1"
 license = "MIT"
 description = "WebSocket-controlled media proxy streaming to LED displays via DDP"
-repository = "https://github.com/stuartparmenter/media-proxy"
+repository = "https://github.com/pavlov-net/media-proxy"
 authors = ["Stuart Parmenter"]
 
 [[bin]]
@@ -56,9 +56,6 @@ which = "8"
 url = "2.5"
 percent-encoding = "2"
 
-# Media — Phase 1. We spawn ffmpeg via direct `tokio::process::Command`;
-# `ffmpeg-sidecar` was considered but its auto-download + progress-parse
-# features aren't needed here, and vendoring a Command spawn is ~50 LOC.
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp", "gif", "bmp", "tiff"] }
 fast_image_resize = { version = "6", features = ["image"] }
 lcms2 = { version = "6", features = ["static"] }
@@ -86,9 +83,7 @@ lto = "thin"
 codegen-units = 1
 strip = "debuginfo"
 
-# Release-shaped profile without LTO — roughly half the build time of
-# `release`, runtime perf within a few percent. Use during iteration when
-# you want production codegen but don't need a shipping binary.
+# Disables LTO for faster local builds.
 [profile.release-fast]
 inherits = "release"
 lto = false
@@ -98,8 +93,7 @@ strip = "none"
 [profile.dev]
 opt-level = 1
 
-# Compile dependencies at full optimization once, then cache. Our crate
-# stays at `opt-level = 1` (above) so incremental rebuilds remain cheap.
+# Optimize cached dependencies without slowing incremental application builds.
 [profile.dev.package."*"]
 opt-level = 3
 
@@ -107,7 +101,6 @@ opt-level = 3
 unsafe_code = "forbid"
 
 [lints.clippy]
-# Block dangerous patterns; pedantic/nursery stay opt-in crate-wide
 dbg_macro = "deny"
 todo = "warn"
 unwrap_used = "warn"

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ cargo build --locked --release
 Use `ddp-view --help` to configure a terminal DDP receiver for testing without a
 physical display.
 
+Animated WebP files that clear a frame before drawing the next can retain ghost
+pixels because of disposal bugs in the upstream decoder.
+
 ## Run checks
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -1,432 +1,79 @@
 # Media Proxy
 
-Stream videos, GIFs, still images, and YouTube content to tiny LED/LCD displays (e.g., ESPHome devices using DDP) with smart resizing, optional color-range expansion, and packet pacing. Exposes a WebSocket control API and pushes pixel data over UDP using the DDP format.
+Media Proxy streams images and video to displays over DDP (UDP), controlled through
+WebSocket messages. It runs as a standalone Rust binary or a
+[Home Assistant add-on](https://github.com/stuartparmenter/media-proxy-addon).
+For ESPHome displays, see [ddp-esphome](https://github.com/pavlov-net/ddp-esphome).
 
-Available as a Home Assistant add-on or standalone Rust binary.
+## Install and run
 
----
+Linux releases contain `media-proxy` and `ddp-view` for x86-64 and aarch64. The
+binaries use musl and statically linked Little CMS. The x86-64 build does not
+require AVX2.
 
-## What you get
+Download the archive and matching checksum from
+[Releases](https://github.com/pavlov-net/media-proxy/releases). For example:
 
-- Unified HTTP/WebSocket server (default port `8788`) with WebSocket control API and REST endpoints.
-- Video decoding via subprocess `ffmpeg` with hardware acceleration (CUDA, QSV, VAAPI, VideoToolbox, D3D11VA).
-- Smart fit modes (`cover`, `pad`, `auto`), optional TV→PC range expansion, and automatic black-bar crop.
-- Static + animated image pipeline (PNG, JPEG, GIF, APNG, WebP) with disposal/blend handling and an LRU frame cache.
-- UDP DDP sender with optional packet spreading, pacing, and still-frame redundancy.
-- Companion `ddp-view` binary — a terminal DDP receiver that renders 64×64 frames using half-block characters, useful for end-to-end testing without an LED panel.
-
----
-
-## Requirements
-
-- Rust 1.98.1+ (edition 2024) — only needed to build from source
-- `ffmpeg` and `ffprobe` on `PATH` for video sources
-- Network access to your displays (UDP, typically port 4048)
-
-YouTube and other web-page sources use an external `yt-dlp` executable. The
-[Home Assistant add-on](https://github.com/stuartparmenter/media-proxy-addon)
-installs yt-dlp, its EJS solver package, Deno, and FFmpeg. Standalone users install
-these separately; direct files, images, and streams do not require yt-dlp.
-
----
-
-## Installation
-
-### Home Assistant Add-on
-
-1. In Home Assistant, open **Settings → Add-ons → Add-on Store**.
-2. Click **⋮ → Repositories** and add:
-   `https://github.com/stuartparmenter/homeassistant-addons`
-3. Find **Media Proxy** in the list and click **Install**.
-4. After install, open the add-on:
-   - Optionally enable **Start on boot** and **Watchdog**.
-   - Add configuration (see below).
-   - Click **Start**, then check the **Log** tab to verify it's running.
-
-### Standalone Binary
-
-Linux releases provide `media-proxy` and `ddp-view` for x86-64 and aarch64, built
-with musl and a statically linked Little CMS. The x86-64 binary supports the
-baseline instruction set; AVX2 is not required. Download the matching `.tar.gz`
-and `.tar.gz.sha256` from [Releases](https://github.com/pavlov-net/media-proxy/releases),
-then verify and extract them:
-
-```bash
+```sh
 sha256sum -c media-proxy-1.0.0-x86_64-unknown-linux-musl.tar.gz.sha256
 tar -xzf media-proxy-1.0.0-x86_64-unknown-linux-musl.tar.gz
 ./media-proxy --host 0.0.0.0 --port 8788
 ```
 
-To build from source (Rust 1.98.1):
+Video sources require `ffmpeg` and `ffprobe` on `PATH`. Allow outbound UDP to the
+display's DDP port and inbound TCP to the server's control port. Run
+`media-proxy --help` for CLI options.
 
-```bash
-git clone https://github.com/pavlov-net/media-proxy.git
-cd media-proxy
-cargo build --release
-./target/release/media-proxy --host 0.0.0.0 --port 8788
-```
+### Web-page sources
 
-For YouTube, install [Deno](https://docs.deno.com/runtime/getting_started/installation/)
-(2.6.6 or newer) and yt-dlp with its default extras, then ensure both executables
-are on the service's `PATH`:
+Install [Deno](https://docs.deno.com/runtime/getting_started/installation/)
+2.6.6 or newer and yt-dlp with its EJS solver:
 
-```bash
+```sh
 uv tool install 'yt-dlp[default]'
 yt-dlp --version
 deno --version
 ```
 
-The `[default]` extra installs `yt-dlp-ejs`, which supplies the JavaScript solver
-used for YouTube signatures. Installing bare `yt-dlp` can leave that solver
-missing. Keep yt-dlp and its matching EJS dependency current; `curl-cffi` is an
-optional extra for sites needing browser impersonation. Core startup logs show
-whether a local yt-dlp, an explicit `resolver.url`, or no resolver was selected.
-An external resolver is optional, and takes precedence when configured:
+Both executables must be on the service's `PATH`. Keep yt-dlp and its matching
+`yt-dlp-ejs` dependency up to date for YouTube extraction. The `curl-cffi` extra
+is optional for sites requiring browser impersonation. Direct media files and
+streams do not require yt-dlp.
 
-```yaml
-resolver:
-  url: http://127.0.0.1:8790/resolve
-  timeout_ms: 30000
+### Build from source
+
+Install the toolchain specified in [rust-toolchain.toml](https://github.com/pavlov-net/media-proxy/blob/main/rust-toolchain.toml), then:
+
+```sh
+git clone https://github.com/pavlov-net/media-proxy.git
+cd media-proxy
+cargo build --locked --release
+./target/release/media-proxy --host 0.0.0.0 --port 8788
 ```
 
-CLI flags:
+## Configure and control streams
 
-```
---host <HOST>            [default: 0.0.0.0]
---port <PORT>            [default: 8788]
---config <CONFIG>        Path to YAML/TOML/JSON config file (optional)
---log-level <LEVEL>      debug | info | warning | error | critical
-```
+- [Configuration](docs/configuration.md): server settings, image/video processing,
+  and resolver selection.
+- [Control API](docs/api.md): WebSocket messages and HTTP endpoints.
+- [Home Assistant setup](https://github.com/stuartparmenter/media-proxy-addon#installation):
+  add-on installation and configuration paths.
 
-Configuration also accepts `MEDIA_PROXY__SECTION__KEY=value` env-var overrides
-(e.g. `MEDIA_PROXY__IMAGE__GAMMA_CORRECT=true`).
+Use `ddp-view --help` to configure a terminal DDP receiver for testing without a
+physical display.
 
----
+## Run checks
 
-## Configuration
-
-By default the server runs on `host: 0.0.0.0`, `port: 8788`.
-
-You can optionally provide a configuration file using the `--config` argument. Without a config file, the application uses built-in defaults.
-
-### Example config file
-
-```yaml
-hw:
-  prefer: auto
-
-video:
-  expand_mode: 2        # 0=never, 1=auto(limited->full), 2=force
-  fit: auto             # cover | pad | auto
-  autocrop:
-    enabled: false      # Disabled by default for safety
-    probe_frames: 24    # More frames for stability
-    luma_thresh: 16     # Lower threshold for conservative detection
-    max_bar_ratio: 0.15 # More conservative cropping limit
-    min_bar_px: 2
-
-playback:
-  loop: true
-
-youtube:
-  60fps: true           # Try 60fps at 720p first, then fall back to resolution-optimized selection
-
-image:
-  method: lanczos       # lanczos | bicubic | bilinear | box | nearest | auto
-  gamma_correct: false
-  color_correction: true
-  unsharp:
-    amount: 0.0
-    radius: 0.6
-    threshold: 2
-  frame_cache_mb: 32    # Max memory for cached frames (0 = disabled)
-  frame_cache_min_frames: 5  # Only cache if animation has >= N frames
-
-log:
-  level: info
-  metrics: true
-  rate_ms: 5000
-  send_ms: false
-
-net:
-  win_timer_res: true
-  spread_packets: true
-  spread_max_fps: 60
-  spread_min_ms: 3.0
-  spread_max_sleeps: 0
-
-playback_still:
-  redundancy: 3  # Send each packet this many times for reliability
+```sh
+cargo fmt --package media-proxy -- --check
+cargo clippy --locked --all-targets -- -D warnings
+cargo test --locked --all-targets
+cargo build --locked --bins
+python3 tests/smoke.py --binary target/debug/media-proxy
 ```
 
----
-
-## Video Processing Options
-
-### Fit Modes
-
-- **`auto` (recommended)**: Smart mode that avoids unnecessary processing
-  - When source and target aspect ratios match: direct scaling with no padding/cropping
-  - When aspect ratios differ: falls back to `pad` behavior (preserves all content)
-  - Optimal for most use cases - maximum efficiency with no content loss
-
-- **`pad`**: Always preserves all content by adding black bars when needed
-  - Guarantees no content is cropped
-  - May add unnecessary padding even when aspect ratios match
-
-- **`cover`**: Fills display completely but may crop content
-  - Scales to fill the display and crops excess content
-  - Use only when you're okay with potentially losing parts of the image/video
-
-### Automatic Black Bar Cropping
-
-Autocrop automatically detects and removes letterbox/pillarbox bars from videos. It's disabled by default to avoid cropping legitimate dark content.
-
-```yaml
-video:
-  autocrop:
-    enabled: false      # Enable if needed for letterboxed content
-    probe_frames: 24    # Samples more frames for stability
-    luma_thresh: 16     # Conservative threshold to avoid dark content
-    max_bar_ratio: 0.15 # Won't crop more than 15% from any edge
-```
-
-**How it works:**
-- Analyzes the first 24 frames to detect consistent black borders
-- Uses conservative settings to minimize false positives
-- Once detected, applies the same crop to the entire stream
-
-**Considerations:**
-- May crop dark scenes or fade-to-black sequences if they occur early in the video
-- Best suited for content with consistent letterboxing throughout
-
----
-
-## YouTube Optimization
-
-Media Proxy intelligently selects YouTube formats based on your display size and hardware acceleration:
-
-**Resolution Matching:** Automatically selects the most appropriate resolution for your display:
-- 64×64 displays use 144p → 240p → 360p streams
-- 480×480 displays use 480p → 360p → 720p streams
-- Reduces bandwidth usage while maintaining visual quality
-
-**60fps Content:** With `youtube.60fps: true` (default), prioritizes smooth motion:
-- Attempts 60fps at 720p first, regardless of display size (YouTube only offers 60fps at 720p+)
-- Falls back to resolution-matched formats if 60fps unavailable
-- Set to `false` to prioritize bandwidth/CPU efficiency over framerate
-
-**Hardware Acceleration:** Codec selection optimized for your acceleration method:
-- **VAAPI:** AV1 → VP9 → H.265 → H.264 (modern codec preference)
-- **Quick Sync:** H.265 → H.264 → AV1 (optimized for Intel's HEVC support)
-- **CUDA:** AV1 → H.265 → H.264 (RTX 30+ series supports AV1 decode)
-- **CPU fallback:** H.264 → VP9 → H.265 (efficiency-focused)
-
-Enable `log.level: debug` to see format selection details.
-
----
-
-## WebSocket Control API
-
-Media Proxy provides a WebSocket control API on `/control` (default port `:8788`) for managing video/image streams to devices.
-
-### Connection & Handshake
-
-1. **Connect** to `ws://localhost:8788/control`
-2. **Send handshake** message:
-```json
-{
-  "type": "hello",
-  "device_id": "my_device_123"
-}
-```
-3. **Receive acknowledgment**:
-```json
-{
-  "type": "hello_ack",
-  "server_version": "media-proxy/1.0"
-}
-```
-
-### Control Messages
-
-#### Start Stream
-```json
-{
-  "type": "start_stream",
-  "out": 5,
-  "w": 64,
-  "h": 64,
-  "src": "https://example.com/video.mp4",
-  "ddp_port": 4048,
-  "fit": "auto",
-  "loop": true,
-  "hw": "auto"
-}
-```
-
-**Required parameters:**
-- `out`: Output ID (integer ≥ 1)
-- `w`: Display width in pixels (integer > 0)
-- `h`: Display height in pixels (integer > 0)
-- `src`: Media source (file path, HTTP URL, or YouTube URL)
-
-**Optional parameters:**
-- `ddp_host`: Target hostname/IP for DDP packets (default: client's IP address)
-- `ddp_port`: DDP output port (default: 4048)
-- `fit`: Resize mode - `cover`, `pad`, or `auto` (default: `auto`)
-  - `auto`: Smart fit - scales directly when aspect ratios match, adds padding when they don't (recommended)
-  - `pad`: Always scales to fit and adds black bars if needed (never crops content)
-  - `cover`: Scales to fill and crops excess content (may lose parts of the image/video)
-- `loop`: Loop media playback (boolean, default from config)
-- `hw`: Hardware acceleration - `auto`, `none`, `cuda`, `qsv`, `vaapi`, `videotoolbox`, `d3d11va`
-- `fmt`: Pixel format - `rgb888`, `rgb565le`, `rgb565be` (default: `rgb888`)
-- `expand`: Color range expansion - `0` (never), `1` (auto), `2` (force)
-- `pace`: Frame pacing frequency in Hz (default: 0)
-- `ema`: EMA filter alpha (0.0-1.0, default: 0.0)
-
-#### Stop Stream
-```json
-{
-  "type": "stop_stream",
-  "out": 5
-}
-```
-
-#### Update Stream
-Updates an existing stream with new parameters (stops and restarts internally):
-```json
-{
-  "type": "update",
-  "out": 5,
-  "src": "https://example.com/new_video.mp4",
-  "loop": false
-}
-```
-
-### Error Responses
-```json
-{
-  "type": "error",
-  "code": "bad_request",
-  "message": "start requires Display width (missing: w)"
-}
-```
-
-**Error codes:**
-- `proto`: Protocol violation (invalid handshake, bad JSON)
-- `bad_type`: Unknown message type
-- `bad_request`: Missing/invalid parameters
-- `server_error`: Internal server error
-
-### Example JavaScript Client
-```javascript
-const ws = new WebSocket('ws://localhost:8788/control');
-
-ws.onopen = () => {
-  // Handshake
-  ws.send(JSON.stringify({
-    type: 'hello',
-    device_id: 'browser_client'
-  }));
-};
-
-ws.onmessage = (event) => {
-  const msg = JSON.parse(event.data);
-  if (msg.type === 'hello_ack') {
-    // Start streaming
-    ws.send(JSON.stringify({
-      type: 'start_stream',
-      out: 5,
-      w: 64,
-      h: 64,
-      src: 'https://media.giphy.com/media/3o6Zt481isNVuQI1l6/giphy.gif'
-    }));
-  }
-};
-```
-
----
-
-## HTTP REST API
-
-Media Proxy provides HTTP endpoints for health checks and placeholder image generation.
-
-### GET `/api/internal/placeholder/{spec}`
-
-Generate placeholder images on-the-fly for testing and development. Useful for validating stream configurations without external media sources.
-
-**URL patterns:**
-- `/api/internal/placeholder/64x64.png` - Gray square with dimensions as text
-- `/api/internal/placeholder/600x400/orange.png` - Orange background, auto-contrast text
-- `/api/internal/placeholder/600x400/ff0000/white.png` - Red background, white text
-- `/api/internal/placeholder/800.png?text=Hello+World` - Custom text
-
-**Parameters:**
-- **Size**: `{width}x{height}` or `{size}` for square (10-4096px)
-- **Background color** *(optional)*: CSS color name or hex (e.g., `orange`, `f00`, `ff0000`, `#00ff00`)
-- **Text color** *(optional)*: CSS color name or hex (auto-contrasted if not specified)
-- **Query param `text`** *(optional)*: Custom text (defaults to dimensions). Use `\n` for newlines.
-
-**Internal Protocol Shorthand:**
-
-For use with WebSocket `start_stream` commands, the `internal:` protocol provides a shorthand:
-
-```json
-{
-  "type": "start_stream",
-  "out": 1,
-  "w": 64,
-  "h": 64,
-  "src": "internal:placeholder/64x64.png"
-}
-```
-
-The `internal:` URL automatically resolves to `http://{server_host}/api/internal/placeholder/64x64.png` using the server's actual host and port.
-
-**Examples:**
-```bash
-# Generate 64x64 gray placeholder
-curl http://localhost:8788/api/internal/placeholder/64x64.png --output test.png
-
-# Orange background with custom text
-curl http://localhost:8788/api/internal/placeholder/600x400/orange.png?text=Test%20Image --output test.png
-```
-
----
-
-## Using it with ESPHome
-
-See: [lvgl-ddp-stream](https://github.com/stuartparmenter/lvgl-ddp-stream) for ESPHome integration examples.
-
----
-
-## Ports & networking
-
-- **WebSocket control:** TCP `8788` (configurable).
-- **DDP to devices:** UDP from the add-on to your displays on the port you specify per stream.
-
----
-
-## Logs & troubleshooting
-
-- Open the add-on’s **Log** tab to view server output.
-- You’ll see decode path selection, filter-graph rebuilds, and metrics (fps, pps, jitter, drops).
-- Common issues:
-  - **No frames until page reload:** Ensure your client starts streaming after WebSocket connect.
-  - **YouTube not playing:** The add-on must be able to reach YouTube; outbound internet must be allowed.
-  - **Device not receiving frames:** Check UDP reachability and that pixel format matches your device.
-
----
-
-## Rust cutover and validation
-
-The retained media APIs and Python configuration defaults are covered by a
-captured defaults fixture and by `python3 tests/smoke.py --binary target/debug/media-proxy`.
-The smoke test generates local media using FFmpeg and checks health/placeholder endpoints,
-WebSocket control, and real UDP output.
-
-Home Assistant entity/template drawing was intentionally removed in the Rust
-rewrite. `/api/internal/homeassistant/*` returns 501; it is not an add-on feature
-that will be restored by this migration. The `/api/convert/animimg` utility was
-also removed; frame-to-ZIP conversion is outside the streaming service’s scope.
+The smoke test requires FFmpeg. It exercises HTTP, WebSocket and DDP playback
+using local media, including animation/video loop boundaries. With yt-dlp on
+`PATH`, it also tests extraction from a local HTML page.
+[Disposal fixtures](https://github.com/pavlov-net/media-proxy/blob/main/tests/fixtures/animated/README.md) use independent raw-subframe
+compositing references.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,116 @@
+# Control API
+
+WebSocket control uses `/control`. Each connection owns its streams; closing the
+connection cancels them. DDP output uses UDP independently of the control socket.
+
+## Connect
+
+Connect to `ws://localhost:8788/control` and send `hello` as the first text message:
+
+```json
+{"type":"hello","device_id":"my_display"}
+```
+
+`device_id` is optional. The response has type `hello_ack` and a `server_version`
+string containing `media-proxy/` followed by the crate version. The server sends
+WebSocket ping frames; clients must handle the protocol's pong response.
+
+## Start a stream
+
+```json
+{
+  "type": "start_stream",
+  "out": 5,
+  "w": 64,
+  "h": 64,
+  "src": "https://example.com/video.mp4"
+}
+```
+
+| Field | Contract |
+| --- | --- |
+| `out` | Required nonnegative output ID. DDP transmits its low eight bits. |
+| `w`, `h` | Required nonzero pixel dimensions, bounded by `MAX_OUTPUT_DIM` in [field validation](https://github.com/pavlov-net/media-proxy/blob/main/src/control/fields.rs). |
+| `src` | Required source: file path, `file:///absolute/path` URL, HTTP media/page URL, streaming URL, or `internal:` shorthand. |
+| `ddp_host` | Destination IP address; omitted means the control client's address. Hostnames are not accepted. |
+| `ddp_port` | Nonzero UDP destination port; omitted uses the DDP port in `StreamFields::from_start`. |
+| `fit` | `auto`, `pad` or `cover`; omitted inherits `video.fit`. See [resize modes](configuration.md#resize-modes). |
+| `loop` | Repeat playback; omitted inherits `playback.loop`. |
+| `hw` | `auto`, `none`, `cuda`, `qsv`, `vaapi`, `videotoolbox` or `d3d11va`; omitted inherits `hw.prefer`. Available backends depend on the host and FFmpeg build. |
+| `fmt` | `rgb888`, `rgb565le` or `rgb565be`; omitted uses RGB888. `rgbw` is accepted as RGB888 output. |
+| `expand` | `0`: FFmpeg defaults; `1`: auto-detected input range to full range; `2`: limited input range to full range. Omitted inherits `video.expand_mode`. |
+| `pace` | Integer sampling rate in Hz. Zero or omitted follows source cadence. |
+| `ema` | Frame smoothing alpha in `[0, 1]` for paced playback; zero or omitted disables smoothing. |
+
+File paths refer to the server's filesystem. Relative paths resolve from its
+working directory; the Home Assistant add-on exposes media files under `/media`.
+
+A successful request returns `ack` with `out` and an `applied` object containing
+resolved stream parameters. The acknowledgement confirms acceptance; decoding
+runs asynchronously. Stream failures appear in server logs.
+
+Streams reserve a destination IP and eight-bit output ID. Starting another stream
+with the same pair displaces the prior one, including across connections.
+
+## Update or stop a stream
+
+`update` restarts a stream with supplied fields; omitted fields retain their
+values. The stream must belong to the connection.
+
+```json
+{"type":"update","out":5,"src":"https://example.com/animation.gif","loop":false}
+```
+
+`stop_stream` cancels the selected stream and returns `ack`, including when no
+matching stream exists:
+
+```json
+{"type":"stop_stream","out":5}
+```
+
+Both messages accept `ddp_host` to select a destination other than the control
+client's IP. Use the same destination as the start request.
+
+## Ping and errors
+
+JSON `ping` returns `pong` with the same `t` value. An omitted `t` is returned as
+null. This message is separate from WebSocket ping/pong frames.
+
+```json
+{"type":"ping","t":123.5}
+```
+
+Errors have `type: error`, `code` and `message`. Invalid handshakes use `proto`;
+invalid requests and unknown outputs use `bad_request`. See
+[`ControlError`](https://github.com/pavlov-net/media-proxy/blob/main/src/error.rs) for the error mapping. Unknown JSON fields are
+ignored.
+
+## HTTP endpoints
+
+### GET `/api/system/health`
+
+Returns JSON with `status: ok` and `service: media-proxy`.
+
+### GET `/api/internal/placeholder/{spec}`
+
+Returns a PNG containing text. The specification accepts a square size or
+`width`x`height`, optional background/text colors, and a `.png` suffix:
+
+```text
+/api/internal/placeholder/64x64.png
+/api/internal/placeholder/600x400/orange.png
+/api/internal/placeholder/600x400/ff0000/white.png
+/api/internal/placeholder/800.png?text=Hello+World
+```
+
+Dimensions must be within the bounds enforced by
+[`placeholder`](https://github.com/pavlov-net/media-proxy/blob/main/src/api/internal/placeholder.rs). Colors accept supported names
+or hex; percent-encode `#` in a URL. Omitted colors use gray and contrasting text.
+The `text` query value defaults to dimensions and accepts literal `\n` for line breaks.
+
+For a stream source, `internal:placeholder/64x64.png` expands to the server's
+`/api/internal/placeholder/64x64.png` URL using the control connection's Host header.
+
+### GET `/api/internal/homeassistant/{entity}`
+
+Returns 501. Home Assistant entity/template rendering is unsupported.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,88 @@
+# Configuration
+
+`--config` loads YAML, TOML or JSON. Missing values use the defaults in
+[`Config`](https://github.com/pavlov-net/media-proxy/blob/main/src/config.rs). Environment variables override file values using
+`MEDIA_PROXY__SECTION__KEY`, such as `MEDIA_PROXY__IMAGE__GAMMA_CORRECT=true`.
+The listening address and port are CLI options; see `media-proxy --help`.
+
+This example disables hardware decoding and enables video border detection:
+
+```yaml
+hw:
+  prefer: none
+video:
+  autocrop:
+    enabled: true
+```
+
+## Processing settings
+
+| Setting | Meaning |
+| --- | --- |
+| `hw.prefer` | Hardware preference when a stream omits `hw`; see [stream fields](api.md#start-a-stream). |
+| `video.fit` | Resize mode when a stream omits `fit`. |
+| `video.expand_mode` | Color-range expansion when a stream omits `expand`. |
+| `video.autocrop.enabled` | Detect video borders during startup. Dark opening scenes can be mistaken for borders. |
+| `video.autocrop.probe_frames` | Number of grayscale frames to sample. |
+| `video.autocrop.luma_thresh` | Luma threshold for classifying a row or column as a border. |
+| `video.autocrop.max_bar_ratio` | Maximum fraction of each edge considered for cropping. |
+| `video.autocrop.min_bar_px` | Minimum detected border width in source pixels. |
+| `playback.loop` | Loop setting when a stream omits `loop`. |
+| `image.method` | Resampling filter: `lanczos`, `bicubic`, `bilinear`, `box`, `nearest` or `auto`. |
+| `image.gamma_correct` | Resize in linear-light RGB. |
+| `image.color_correction` | Convert supported embedded ICC profiles to sRGB. |
+| `image.unsharp.amount`, `radius`, `threshold` | Sharpening controls; zero amount disables sharpening. |
+| `image.frame_cache_mb` | Processed animation cache budget in MiB; zero disables retention. |
+| `image.frame_cache_min_frames` | Minimum sequence length eligible for caching. |
+| `playback_still.redundancy` | Copies per packet for the first frame of non-looping native playback, clamped to at least one. Looping and paced playback send one copy. |
+
+### Resize modes
+
+`pad` preserves the source aspect ratio and fills uncovered pixels with black.
+`cover` fills the display and crops excess content. `auto` scales directly when
+source and display aspect ratios are close; otherwise it uses `pad`.
+
+Autocrop samples the beginning of a video at reduced resolution, takes the median
+border width for each edge, and applies that crop throughout playback. A failed
+probe leaves the video uncropped.
+
+### YouTube formats and caching
+
+`youtube.60fps` tries 720p 60fps formats before resolution-matched alternatives.
+Disable it to prioritize resolution matching. Format selection considers target
+height and hardware preference; the exact codec/resolution order is defined by
+[`build_format`](https://github.com/pavlov-net/media-proxy/blob/main/src/yt_dlp/format.rs).
+
+`youtube.cache.enabled` lets looping videos with a known size at or below
+`youtube.cache.max_size` use FFmpeg's file cache. The size limit is in bytes.
+
+## Resolver selection
+
+An explicit `resolver.url` takes precedence over local yt-dlp. Without it, the
+server detects yt-dlp on `PATH`. Direct media bypasses extraction. Startup logs
+identify the selected resolver.
+
+```yaml
+resolver:
+  url: http://127.0.0.1:8790/resolve
+  timeout_ms: 30000
+```
+
+The external endpoint accepts JSON POST requests and returns a stream URL with
+optional headers and metadata. See [`ResolveRequest` and `ResolveResponse`](https://github.com/pavlov-net/media-proxy/blob/main/src/resolver/mod.rs)
+for the schema. `resolver.timeout_ms` bounds extraction in milliseconds.
+
+## Network and logging settings
+
+| Setting | Meaning |
+| --- | --- |
+| `net.user_agent` | HTTP User-Agent for media requests unless extraction supplies one. |
+| `net.spread_packets` | Spread a frame's DDP packets across its frame interval. |
+| `net.spread_max_fps` | Disable spreading above this frame rate. |
+| `net.spread_min_ms` | Minimum spacing between packet groups in milliseconds. |
+| `net.spread_max_sleeps` | Limit sleeps per frame; zero leaves the count uncapped. |
+| `net.win_timer_res` | Request a finer Windows timer resolution. |
+| `log.level` | Logging severity; `--log-level` overrides it. |
+| `log.metrics` | Enable periodic DDP sender metrics. |
+| `log.rate_ms` | Metrics reporting interval in milliseconds. |
+| `log.send_ms` | Accepted configuration key with no runtime effect. |

--- a/src/api/internal/homeassistant.rs
+++ b/src/api/internal/homeassistant.rs
@@ -1,7 +1,4 @@
-//! `GET /api/internal/homeassistant/{spec}` — Home Assistant lookup shim.
-//!
-//! Entity/template drawing was intentionally removed in the Rust rewrite.
-//! Keep an explicit 501 response for old source URLs.
+//! Home Assistant drawing URLs return 501; entity/template drawing is unsupported.
 
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
@@ -9,7 +6,7 @@ use axum::response::{IntoResponse, Response};
 pub async fn homeassistant() -> Response {
     (
         StatusCode::NOT_IMPLEMENTED,
-        "Home Assistant entity/template drawing is no longer supported",
+        "Home Assistant entity/template drawing is unsupported",
     )
         .into_response()
 }

--- a/src/api/internal/mod.rs
+++ b/src/api/internal/mod.rs
@@ -1,7 +1,4 @@
-//! `internal:` URL scheme endpoints.
-//!
-//! `internal:placeholder/...` → this server
-//! `internal:ha/...` → Home Assistant (delegated to `media-proxy-addon`)
+//! Placeholder image generation and the unsupported Home Assistant drawing endpoint.
 
 pub mod homeassistant;
 pub mod placeholder;

--- a/src/api/internal/placeholder.rs
+++ b/src/api/internal/placeholder.rs
@@ -1,10 +1,5 @@
-//! `GET /api/internal/placeholder/{spec}` — generate a PNG with text.
-//!
-//! URL patterns (extension required):
-//!   /placeholder/64x64.png
-//!   /placeholder/600x400/orange/white.png
-//!   /placeholder/600x400/ff0000.png
-//!   /placeholder/800.png?text=Hello+World
+//! PNG placeholders with optional dimensions, colors and BBCode text.
+//! The spec ends in `.png`; dimensions are `widthxheight` or a square side.
 
 use std::io::Cursor;
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,4 +1,4 @@
-//! HTTP + WebSocket server.
+//! HTTP and WebSocket server.
 
 pub mod health;
 pub mod internal;
@@ -8,7 +8,7 @@ pub use state::AppState;
 
 use axum::http::HeaderMap;
 
-/// Extract the `Host` header for use as `server_host` in source
+/// Extracts the `Host` header for use as `server_host` in source
 /// normalization. Falls back to `"localhost"` when missing or non-ASCII so
 /// `internal:` rewriting still produces a valid URL.
 pub fn host_header(headers: &HeaderMap) -> &str {
@@ -36,7 +36,7 @@ pub async fn serve(addr: SocketAddr, config: Config) -> Result<()> {
     let config = Arc::new(config);
     let resolver: Arc<dyn Resolver> = build_resolver(&config)?;
 
-    // Warm hwaccel probe off the request path (~25-100ms per backend).
+    // Start hardware probing in the background to reduce first-request work.
     tokio::task::spawn_blocking(|| {
         let probed = crate::video::hwaccel::available();
         info!(?probed, "hwaccel probe complete");
@@ -66,9 +66,8 @@ pub async fn serve(addr: SocketAddr, config: Config) -> Result<()> {
     Ok(())
 }
 
-/// Explicit `resolver.url` wins; otherwise auto-detect local `yt-dlp`;
-/// otherwise fail closed. Always wrapped in `PassthroughLayer` so direct
-/// media short-circuits.
+/// Selects an external resolver or local yt-dlp. Direct media bypasses resolution;
+/// other inputs fail when neither resolver is available.
 fn build_resolver(config: &Arc<Config>) -> Result<Arc<dyn Resolver>> {
     let timeout = Duration::from_millis(config.resolver.timeout_ms);
     let inner: Box<dyn Resolver> = if let Some(url) = &config.resolver.url {

--- a/src/bin/ddp_view.rs
+++ b/src/bin/ddp_view.rs
@@ -1,15 +1,5 @@
-//! `ddp-view` — terminal DDP receiver for end-to-end testing.
-//!
-//! Listens on a UDP port for DDP packets, assembles frames per `out_id`, and
-//! renders them in the terminal using upper-half-block characters (one
-//! terminal row = two LED rows, so a 64×64 frame fits in 64×32 cells).
-//!
-//! Optionally connects to a running `media-proxy` over WebSocket and sends a
-//! `start_stream` so the proxy targets *this* viewer:
-//!
-//! ```text
-//! ddp-view --connect ws://localhost:8788/control --src /tmp/test.png
-//! ```
+//! Terminal DDP receiver and optional WebSocket client. Frames use upper-half
+//! block glyphs, displaying two pixel rows per terminal row.
 
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
@@ -34,7 +24,7 @@ const PIXEL_RGB888: u8 = 0x0B;
 const PIXEL_RGB565_BE: u8 = 0x61;
 const PIXEL_RGB565_LE: u8 = 0x62;
 
-/// Cap render rate so high-fps streams don't thrash the terminal.
+/// Limits rendering frequency to avoid terminal saturation.
 const RENDER_INTERVAL: Duration = Duration::from_millis(33); // ~30 fps
 
 #[derive(Debug, Parser)]
@@ -48,20 +38,19 @@ struct Cli {
     #[arg(long, default_value = "0.0.0.0")]
     listen_host: IpAddr,
 
-    /// Display width (pixels). Must match the source you're receiving.
+    /// Frame width in pixels; must match the received stream.
     #[arg(long, default_value_t = 64)]
     width: u32,
 
-    /// Display height (pixels). Must match the source you're receiving.
+    /// Frame height in pixels; must match the received stream.
     #[arg(long, default_value_t = 64)]
     height: u32,
 
-    /// Filter rendering to a single `out_id`. Default: 1.
+    /// Output ID to render.
     #[arg(long, default_value_t = 1)]
     out: u8,
 
-    /// Connect to a media-proxy WebSocket and drive a stream into this viewer.
-    /// Example: `ws://localhost:8788/control`
+    /// WebSocket URL for controlling a media-proxy stream into this viewer.
     #[arg(long)]
     connect: Option<String>,
 
@@ -69,9 +58,7 @@ struct Cli {
     #[arg(long, requires = "connect")]
     src: Option<String>,
 
-    /// Override `ddp_host` in the start_stream request. Defaults to
-    /// letting media-proxy use the WebSocket client IP (loopback when
-    /// run on the same host).
+    /// Destination IP override; otherwise media-proxy uses the WebSocket client IP.
     #[arg(long, requires = "connect")]
     ddp_host: Option<String>,
 
@@ -83,7 +70,7 @@ struct Cli {
     #[arg(long, default_value = "rgb888", requires = "connect")]
     fmt: String,
 
-    /// Disable looping for the controlled stream (default: loop).
+    /// Plays the controlled stream once.
     #[arg(long, requires = "connect")]
     no_loop: bool,
 }
@@ -98,7 +85,6 @@ async fn main() -> anyhow::Result<()> {
         cli.listen_host, cli.listen_port, cli.out, cli.width, cli.height
     );
 
-    // Optional: open WS, send hello + start_stream, watch for errors.
     let ws_task = if let Some(url) = cli.connect.clone() {
         let src = cli
             .src
@@ -123,7 +109,6 @@ async fn main() -> anyhow::Result<()> {
 
     let frames: Arc<Mutex<HashMap<u8, FrameBuf>>> = Arc::new(Mutex::new(HashMap::new()));
 
-    // Receive loop with graceful Ctrl-C.
     let recv_loop = receive_and_render(sock, frames.clone(), cli.out, cli.width, cli.height);
     tokio::select! {
         r = recv_loop => r?,
@@ -132,12 +117,11 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
-    // Tell media-proxy to stop our stream and let the WS task drain.
     if let Some(handle) = ws_task {
         handle.abort();
     }
 
-    // Restore terminal: reset attrs, show cursor, clear, home.
+    // Restore terminal state on exit.
     print!("\x1b[0m\x1b[?25h\x1b[2J\x1b[H");
     let _ = std::io::stdout().flush();
     Ok(())
@@ -145,9 +129,9 @@ async fn main() -> anyhow::Result<()> {
 
 struct FrameBuf {
     pixel_cfg: u8,
-    /// Frame buffer sized to whatever pixel format the sender is using.
+    /// Payload storage in the sender's pixel format.
     data: Vec<u8>,
-    /// Last time we re-rendered. Used to throttle.
+    /// Rendering timestamp for rate limiting.
     last_render: Instant,
 }
 
@@ -179,7 +163,7 @@ async fn receive_and_render(
             continue;
         }
         let flags = buf[0];
-        // bytes 1=seq is informational, ignore for now
+        // Packet sequence is informational; assembly uses byte offsets.
         let pixel_cfg = buf[2];
         let out_id = buf[3];
         let offset = u32::from_be_bytes([buf[4], buf[5], buf[6], buf[7]]) as usize;
@@ -203,7 +187,6 @@ async fn receive_and_render(
             }
         };
 
-        // Stash payload at offset, growing/resetting if format/size changed.
         let render_now = {
             let mut map = frames.lock();
             let fb = map
@@ -230,9 +213,7 @@ async fn receive_and_render(
                 (fb.pixel_cfg, fb.data.clone())
             };
             let rgb = decode_to_rgb888(&snapshot.1, snapshot.0);
-            // Full clear only on first frame or dimension change. Otherwise
-            // we just rewrite over the existing characters — same width,
-            // same positions, no flash.
+            // Clear on first render or dimension changes; overwrite otherwise to avoid flicker.
             let clear = last_drawn_dims != Some((w, h));
             render(&rgb, w, h, out_id, frames_drawn, bytes_seen, clear);
             last_drawn_dims = Some((w, h));
@@ -261,8 +242,7 @@ fn decode_565(data: &[u8], be: bool) -> Vec<u8> {
         let r5 = (v >> 11) & 0x1F;
         let g6 = (v >> 5) & 0x3F;
         let b5 = v & 0x1F;
-        // Expand 5/6-bit → 8-bit by replicating high bits into the low ones
-        // (matches the standard "color space expansion" used by panel firmware).
+        // Replicate high bits into low bits when expanding RGB565 channels.
         let r = ((r5 << 3) | (r5 >> 2)) as u8;
         let g = ((g6 << 2) | (g6 >> 4)) as u8;
         let b = ((b5 << 3) | (b5 >> 2)) as u8;
@@ -274,12 +254,9 @@ fn decode_565(data: &[u8], be: bool) -> Vec<u8> {
 fn render(rgb: &[u8], w: u32, h: u32, out_id: u8, frames_drawn: u64, bytes_seen: u64, clear: bool) {
     let mut stdout = std::io::stdout().lock();
     if clear {
-        // First render — clear the screen, hide cursor, park at top-left.
         let _ = write!(stdout, "\x1b[2J\x1b[?25l\x1b[H");
     } else {
-        // Subsequent renders — just home the cursor and overwrite. Each
-        // line ends with `\x1b[K` (erase to end of line) so a shrinking
-        // status string doesn't leave digits dangling.
+        // Overwrite in place and erase line endings so shorter status text leaves no residue.
         let _ = write!(stdout, "\x1b[H");
     }
     let _ = writeln!(
@@ -303,11 +280,9 @@ fn render(rgb: &[u8], w: u32, h: u32, out_id: u8, frames_drawn: u64, bytes_seen:
         for x in 0..w {
             let [tr, tg, tb] = pixel(x, y);
             let [br, bg, bb] = pixel(x, y + 1);
-            // Foreground = top half-pixel, background = bottom half-pixel,
-            // glyph = upper half block. Renders square pixels in normal-aspect terminal cells.
+            // Each block glyph combines a foreground upper pixel and background lower pixel.
             let _ = write!(stdout, "\x1b[38;2;{tr};{tg};{tb};48;2;{br};{bg};{bb}m\u{2580}");
         }
-        // Reset attributes + erase any leftovers from a previously-wider frame.
         let _ = writeln!(stdout, "\x1b[0m\x1b[K");
     }
     let _ = stdout.flush();
@@ -334,8 +309,7 @@ async fn run_ws_controller(req: StartStreamReq) -> anyhow::Result<()> {
     let hello = json!({"type": "hello", "device_id": "ddp-view"}).to_string();
     ws.send(Message::Text(hello.into())).await?;
 
-    // start_stream — include only fields the user actually set so server-side
-    // defaults still apply where appropriate.
+    // Omitted optional fields retain the server's defaults.
     let mut start = serde_json::Map::new();
     start.insert("type".into(), json!("start_stream"));
     start.insert("out".into(), json!(req.out));
@@ -352,9 +326,7 @@ async fn run_ws_controller(req: StartStreamReq) -> anyhow::Result<()> {
     let payload = serde_json::Value::Object(start).to_string();
     ws.send(Message::Text(payload.into())).await?;
 
-    // The server PINGs every 15 s; tungstenite handles the PONG reply
-    // automatically. We just need to keep the recv loop draining so we
-    // notice ack/error messages and so PONGs go out promptly.
+    // Reading the socket lets tungstenite send automatic Pong replies.
     while let Some(msg) = ws.next().await {
         match msg {
             Ok(Message::Text(t)) => eprintln!("[ws] {t}"),

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-//! Layered configuration via `figment`: defaults → file (yaml/toml/json) → env → runtime.
+//! Configuration precedence: defaults, optional YAML/TOML/JSON file, then environment.
 
 use std::path::Path;
 
@@ -53,7 +53,8 @@ impl Default for HwConfig {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct VideoConfig {
-    /// 0=never, 1=auto(limited→full), 2=force
+    /// Range expansion: 0 uses ffmpeg defaults, 1 maps auto-detected input to full,
+    /// and 2 maps limited input to full.
     #[serde(default = "default_expand_mode")]
     pub expand_mode: u8,
     #[serde(default = "default_fit")]
@@ -178,10 +179,10 @@ pub struct ImageConfig {
     pub color_correction: bool,
     #[serde(default)]
     pub unsharp: UnsharpConfig,
-    /// Max memory for cached frames (MB, 0 = disabled)
+    /// Shared animation-cache budget in MiB; zero disables cache retention.
     #[serde(default = "default_frame_cache_mb")]
     pub frame_cache_mb: u32,
-    /// Only cache if animation has ≥ N frames
+    /// Minimum frame count for retaining a sequence in the shared cache.
     #[serde(default = "default_frame_cache_min_frames")]
     pub frame_cache_min_frames: u32,
 }
@@ -239,6 +240,7 @@ impl Default for UnsharpConfig {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct LogConfig {
     #[serde(default)]
+    /// Accepted for configuration compatibility; has no runtime effect.
     pub send_ms: bool,
     #[serde(default = "default_log_rate_ms")]
     pub rate_ms: u64,
@@ -306,7 +308,7 @@ impl Default for NetConfig {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PlaybackStillConfig {
-    /// Send each packet this many times for reliability on still frames.
+    /// Packet copies for the first native-cadence frame when looping is disabled.
     #[serde(default = "default_redundancy")]
     pub redundancy: u32,
 }
@@ -342,9 +344,7 @@ impl Default for ResolverConfig {
 }
 
 fn default_resolver_timeout() -> u64 {
-    // Cold-start budget: Python interpreter (~300ms) + yt-dlp imports
-    // (~500ms) + Deno spawn (~1s) + youtubei API + EJS solve (~2-4s).
-    // Warm runs land near 2s; first call after install can be 5-10s.
+    // Allows interpreter startup, extraction, and JavaScript challenge solving.
     30_000
 }
 
@@ -353,7 +353,8 @@ fn default_true() -> bool {
 }
 
 impl Config {
-    /// Load configuration with defaults → optional file → env (`MEDIA_PROXY__*`) overlay.
+    /// Loads defaults, an optional file, then `MEDIA_PROXY__` environment overrides.
+    /// Unsupported file extensions and invalid values return an error.
     pub fn load(path: Option<&Path>) -> Result<Self, ConfigError> {
         let mut fig = Figment::from(Serialized::defaults(Self::default()));
 

--- a/src/control/fields.rs
+++ b/src/control/fields.rs
@@ -1,7 +1,5 @@
-//! Control protocol field definitions + derived `StreamOptions`.
-//!
-//! Serde handles type-level validation; cross-field constraints land in
-//! [`StreamFields::from_start`].
+//! Control message fields and resolved stream parameters.
+//! Start and update requests share `StreamFields::validate`.
 
 use std::net::IpAddr;
 
@@ -43,8 +41,7 @@ pub enum HwPref {
 }
 
 impl HwPref {
-    /// Canonical lowercase name accepted by `ffmpeg -hwaccel` and our own
-    /// `HwBackend::from_str_canon`. `None` → `None`.
+    /// Returns the canonical hardware name, or `None` for disabled acceleration.
     pub fn as_canon(self) -> Option<&'static str> {
         Some(match self {
             Self::Auto => "auto",
@@ -58,10 +55,8 @@ impl HwPref {
     }
 }
 
-/// `start_stream` request.
-///
-/// Required: `out`, `w`, `h`, `src`. Everything else has a default derived
-/// from config.
+/// Start request with required output, dimensions and source.
+/// `StreamFields::from_start` supplies defaults for omitted options.
 #[derive(Debug, Clone, Deserialize)]
 pub struct StartStream {
     pub out: i32,
@@ -124,8 +119,7 @@ pub struct UpdateStream {
     pub ema: Option<f32>,
 }
 
-/// `applied` map in `ack` responses — the canonical view of the resolved
-/// stream parameters returned to the client.
+/// Resolved stream parameters returned in the acknowledgment's `applied` map.
 #[derive(Debug, Clone, Serialize, Default)]
 pub struct AppliedParams {
     pub src: String,
@@ -140,21 +134,16 @@ pub struct AppliedParams {
     pub ddp_host: Option<String>,
 }
 
-/// Narrow the wire-level `out: i32` to the DDP header's `out_id: u8`.
-/// Wire format: low 8 bits verbatim (`out_id & 0xFF`).
+/// Returns the low eight bits of the wire output ID for the DDP header.
 #[inline]
 pub fn output_id_byte(out: i32) -> u8 {
     (out & 0xFF) as u8
 }
 
-/// Upper bound on per-stream width/height. Anything we'd reasonably drive
-/// onto an LED display is far below this; the cap only exists to refuse
-/// inputs that would blow the per-frame allocation budget.
+/// Dimension cap bounds per-frame allocations.
 pub const MAX_OUTPUT_DIM: u32 = 4096;
 
-/// Validated & resolved stream configuration. Construct from a `StartStream`
-/// (or an `UpdateStream` layered over the previous state) via
-/// [`StreamFields::from_start`].
+/// Resolved stream parameters. Start and update constructors validate their values.
 #[derive(Debug, Clone)]
 pub struct StreamFields {
     pub output_id: i32,
@@ -179,11 +168,7 @@ impl StreamFields {
         server_host: &str,
         defaults: &crate::Config,
     ) -> Result<Self, ControlError> {
-        // Parse-time errors that aren't representable in the struct
-        // (string→enum, string→IpAddr, source URL normalization) are
-        // surfaced eagerly here. Numeric range invariants are deferred to
-        // `validate` so `from_start` and `merge_update` enforce the same
-        // post-construction rules.
+        // Start and update share range validation after parsing and source normalization.
         let source =
             crate::stream::url::normalize_source(&req.src, server_host).map_err(ControlError::BadRequest)?;
 
@@ -226,9 +211,7 @@ impl StreamFields {
         Ok(fields)
     }
 
-    /// Post-construction invariants for both start and update flows.
-    /// Width/height caps exist so a malicious or misconfigured client
-    /// can't force giant per-frame allocations (`w * h * channels`).
+    /// Checks output dimensions, output ID, DDP port, expansion mode and EMA range.
     pub fn validate(&self) -> Result<(), ControlError> {
         if self.width == 0 || self.height == 0 {
             return Err(ControlError::BadRequest("w/h must be > 0".into()));
@@ -272,16 +255,8 @@ impl StreamFields {
     }
 }
 
-/// Overlay `update` fields onto a prior stream's resolved state. Any field
-/// left `None` in the update keeps the prior value. The `src` field, if
-/// present, runs through the same [`normalize_source`] pipeline as the
-/// original `from_start`.
-///
-/// Invalid `fmt` and `ddp_host` values fail the request rather than being
-/// silently ignored — the previous behaviour let a client send `fmt: "junk"`
-/// and receive a successful ack while the field had no effect. After all
-/// fields land, the merged value runs through [`StreamFields::validate`]
-/// so update requests can't reach states that `start_stream` would reject.
+/// Merges supplied update fields, retaining omitted values. Normalizes sources
+/// and rejects invalid fields using the same validation as start requests.
 pub fn merge_update(
     prior: &StreamFields,
     upd: &UpdateStream,

--- a/src/control/handler.rs
+++ b/src/control/handler.rs
@@ -1,4 +1,4 @@
-//! Handler dispatch: client messages → orchestrator actions.
+//! Handler dispatch: client messages -> orchestrator actions.
 
 use std::sync::Arc;
 
@@ -44,7 +44,7 @@ impl Handler {
             src = %fields.source,
             "start_stream"
         );
-        // Snapshot the `applied` view after resolving `hw=auto` → concrete backend.
+        // Resolve automatic hardware selection before acknowledging the stream.
         let applied = self.resolve_applied(&fields);
 
         let key = ClientKey::Ddp {
@@ -52,16 +52,14 @@ impl Handler {
             output_id: crate::control::fields::output_id_byte(out_id),
         };
 
-        // Orchestrator spawns the stream task; returns a handle that the
-        // session owns for cancellation.
+        // The session owns the handle so disconnect cleanup can cancel playback.
         let handle = self
             .orch
             .spawn_stream(fields)
             .await
             .map_err(|e| ControlError::Protocol(e.to_string()))?;
 
-        // If an older stream was on this key, the DDP registry already
-        // cancelled it; we just need to drop any handle we were tracking.
+        // The DDP registry signals cancellation before granting a replacement reservation.
         let old_handle = session.streams.lock().insert(key, handle.clone());
         if let Some(old) = old_handle {
             old.cancel();
@@ -100,9 +98,8 @@ impl Handler {
     }
 
     async fn handle_update(&self, session: &Session, req: UpdateStream) -> Result<ServerMsg, ControlError> {
-        // An update is a stream restart that inherits unset fields from the
-        // prior stream for this (dest_ip, output_id). Rejecting uninitialized
-        // updates when there's no active stream matches Python's behavior.
+        // Updates restart the addressed stream and inherit its omitted options.
+        // A stream must exist before it can be updated.
         let out_id = req.out;
         let dest = match req.ddp_host.as_deref() {
             Some(s) => s
@@ -121,7 +118,6 @@ impl Handler {
             handle.fields().clone()
         };
 
-        // Overlay update-supplied fields onto the prior stream's view.
         let merged = crate::control::fields::merge_update(&prior_fields, &req, &session.server_host)?;
         self.start_with_fields(session, merged).await
     }
@@ -164,8 +160,7 @@ impl Handler {
         })
     }
 
-    /// Build the `applied` view returned in `ack`. Resolves `hw=auto` to the
-    /// concrete backend so clients see the actual selection.
+    /// Returns resolved acknowledgment parameters, including a concrete hardware backend.
     fn resolve_applied(&self, fields: &StreamFields) -> crate::control::fields::AppliedParams {
         let mut applied = fields.to_applied();
         if matches!(fields.hw, crate::control::fields::HwPref::Auto)
@@ -182,7 +177,7 @@ impl Handler {
         applied
     }
 
-    /// Convert any `ControlError` into the wire-level error frame.
+    /// Converts any `ControlError` into the wire-level error frame.
     pub fn error_response(e: &ControlError) -> ServerMsg {
         ServerMsg::Error(ErrorMsg {
             code: e.code().into(),

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -1,4 +1,4 @@
-//! Client control plane — WebSocket protocol, session tracking, field
+//! Client control plane: WebSocket protocol, session tracking, field
 //! validation, handler dispatch.
 
 pub mod fields;

--- a/src/control/protocol.rs
+++ b/src/control/protocol.rs
@@ -1,4 +1,4 @@
-//! Wire-level control protocol — serde types for the JSON messages.
+//! JSON control messages and serialization.
 //! Message shapes: `hello`, `start_stream`, `stop_stream`, `update`, `ping`.
 
 use serde::{Deserialize, Serialize};
@@ -44,23 +44,18 @@ pub struct ErrorMsg {
     pub message: String,
 }
 
-/// Free-form start/update payloads come in with arbitrary extra keys (future
-/// fields, per-client experiments). `StartStream`/`UpdateStream` capture the
-/// known fields but we also keep the raw JSON for cases that need it.
+/// Parses a control message, ignoring unknown fields.
 pub fn parse_client_msg(raw: &str) -> serde_json::Result<ClientMsg> {
     serde_json::from_str(raw)
 }
 
 pub fn serialize_server_msg(msg: &ServerMsg) -> String {
     serde_json::to_string(msg).unwrap_or_else(|e| {
-        // Can't encode a JSON error payload as JSON? At this point the best
-        // we can do is send a minimal inline error literal.
+        // Keep a wire error response available if serialization fails.
         format!(r#"{{"type":"error","code":"server_error","message":"{}"}}"#, e)
     })
 }
 
-/// Retained for future compatibility checks: `start_stream` responses echo
-/// back the `applied` map, which surfaces server-resolved values (`hw=auto`
-/// → concrete backend, etc.).
+/// JSON object type for untyped protocol fields.
 #[allow(dead_code)]
 pub type RawMap = serde_json::Map<String, Value>;

--- a/src/control/session.rs
+++ b/src/control/session.rs
@@ -10,8 +10,7 @@ use parking_lot::Mutex;
 use crate::output::sink::StreamId;
 use crate::stream::handle::StreamHandle;
 
-/// Identity of a client-addressed stream on the wire. Currently DDP-only
-/// (`(ddp_host, output_id)`); other sink types extend this enum.
+/// Client-addressed stream identity, independent of the internal `StreamId`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ClientKey {
     Ddp { dest: IpAddr, output_id: u8 },

--- a/src/control/ws.rs
+++ b/src/control/ws.rs
@@ -1,4 +1,4 @@
-//! axum WebSocket handler — wires a connection to the `Handler` dispatcher.
+//! WebSocket sessions with message dispatch and heartbeat timeouts.
 
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -23,14 +23,10 @@ use crate::control::session::Session;
 /// Time the server waits for the initial `hello` before giving up.
 const HELLO_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// How often the server sends a WebSocket-level PING. tungstenite/axum
-/// will auto-respond to ours, and incoming traffic resets the activity
-/// clock — so as long as the TCP path is up, the connection stays open.
+/// Interval between server PING frames; client PONGs count as activity.
 const PING_INTERVAL: Duration = Duration::from_secs(15);
 
-/// If no traffic at all (text, binary, ping, pong) arrives within this
-/// window, the connection is considered dead. Generous enough to absorb
-/// one missed ping/pong round-trip.
+/// Idle threshold checked at each PING tick; tolerates one missed round trip.
 const IDLE_DEAD: Duration = Duration::from_secs(45);
 
 pub async fn upgrade(
@@ -85,9 +81,7 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<AppState>, addr: Socket
         RecvOutcome::Closed => return,
     }
 
-    // Main loop — server-driven heartbeat: send a PING every PING_INTERVAL,
-    // give up if no traffic at all for IDLE_DEAD. The client doesn't have
-    // to send anything (incoming PONGs reset `last_activity`).
+    // PONGs count as activity, so idle clients need no application-level heartbeat.
     let mut last_activity = Instant::now();
     let mut ping_iv = interval(PING_INTERVAL);
     ping_iv.set_missed_tick_behavior(MissedTickBehavior::Skip);
@@ -119,7 +113,7 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<AppState>, addr: Socket
                         break;
                     }
                     Some(Ok(Message::Ping(_) | Message::Pong(_) | Message::Binary(_))) => {
-                        // tungstenite auto-responds to PING; PONG is just bookkeeping.
+                        // tungstenite responds to PING; every received frame resets idle tracking.
                     }
                     Some(Err(e)) => {
                         debug!(client = %addr, error = %e, "ws recv error");
@@ -141,7 +135,6 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<AppState>, addr: Socket
         }
     }
 
-    // Cancel any remaining streams for this session.
     let handles: Vec<_> = session.streams.lock().drain().map(|(_, h)| h).collect();
     for h in handles {
         h.cancel();
@@ -183,10 +176,7 @@ async fn send_error(socket: &mut WebSocket, code: &str, msg: &str) -> Result<(),
     send_server_msg(socket, &err).await
 }
 
-/// Classify benign disconnect errors — Windows `winerror 64/121` and
-/// generic connection-reset — so we can log them at `info` instead of
-/// `warn`. (Kept as a helper for future use; axum's error types don't
-/// currently expose the underlying OS code.)
+/// Recognizes reset, broken-pipe and disconnect messages by text.
 #[allow(dead_code)]
 pub fn is_benign_disconnect(e: &axum::Error) -> bool {
     let s = e.to_string().to_ascii_lowercase();

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,4 @@
-//! Layered error taxonomy. Each subsystem owns its own `thiserror` enum,
-//! converted into this top-level `Error` via `#[from]`.
+//! Subsystem errors and conversions to the top-level `Error`.
 
 use thiserror::Error;
 
@@ -56,10 +55,8 @@ impl From<figment::Error> for ConfigError {
     }
 }
 
-/// Media-layer error taxonomy, library-agnostic.
-///
-/// `retryable` indicates whether the caller's retry loop should attempt again.
-/// `source_url` carries the input URL so logs/errors can identify the stream.
+/// Media errors independent of the decoder or transport library.
+/// `retryable` controls retry eligibility; `source_url` identifies the input.
 #[derive(Debug, Error)]
 pub enum MediaError {
     #[error("network error ({source_url}): {message}")]
@@ -161,16 +158,8 @@ pub enum ResolverError {
 }
 
 impl ResolverError {
-    /// Resolver-time errors are never retried by the orchestrator. This
-    /// matches the Python reference: `yt_dlp.DownloadError`, spawn
-    /// failures, JSON parse errors, and HTTP timeouts during resolution
-    /// all surface immediately. Streaming-time network errors that *can*
-    /// be retried flow through `MediaError::Network::retryable` after
-    /// resolution has already succeeded — they don't come back through
-    /// this enum.
-    ///
-    /// Kept as a method (rather than a flat `false` in the orchestrator)
-    /// so future per-variant selectivity has an obvious extension point.
+    /// Returns false: resolution failures surface immediately. Retryable errors
+    /// after resolution use `MediaError::Network` or `MediaError::Decode`.
     pub fn is_retryable(&self) -> bool {
         false
     }

--- a/src/image/animated/apng.rs
+++ b/src/image/animated/apng.rs
@@ -1,14 +1,5 @@
-//! APNG decoder — the `png` crate gives us per-frame `FrameControl`
-//! (dispose_op, blend_op, offset x/y, size); we run the compositor manually.
-//!
-//! Disposal semantics (APNG spec):
-//! - 0 (NONE)        : leave frame on canvas before next.
-//! - 1 (BACKGROUND)  : clear the rect to transparent black before next.
-//! - 2 (PREVIOUS)    : restore canvas to pre-frame state before next.
-//!
-//! Blend semantics:
-//! - 0 (SOURCE): replace rect pixels entirely.
-//! - 1 (OVER)  : alpha-blend over existing pixels.
+//! APNG decoding with manual SOURCE/OVER blending and NONE/BACKGROUND/PREVIOUS
+//! disposal. Frames are snapshotted before disposal updates the canvas.
 
 use png::{BlendOp, ColorType, DisposeOp};
 
@@ -17,7 +8,7 @@ use crate::error::ImageError;
 
 pub struct ApngDecoder {
     reader: png::Reader<std::io::Cursor<Vec<u8>>>,
-    canvas: Vec<u8>, // RGBA, row-major at (width × height)
+    canvas: Vec<u8>, // RGBA, row-major at (width x height)
     previous_canvas: Vec<u8>,
     width: u32,
     height: u32,
@@ -46,9 +37,7 @@ impl ApngDecoder {
                 "apng: dimensions {width}x{height} exceed cap"
             )));
         }
-        // Pixel-count computed in u64 to dodge u32 overflow; cap at 128 Mpx
-        // (512 MB of RGBA) which is still an order of magnitude beyond any
-        // real-world animated PNG we'd stream to an LED panel.
+        // Widen before multiplication to avoid overflow in the canvas-size check.
         let pixels = u64::from(width) * u64::from(height);
         if pixels > 128 * 1024 * 1024 {
             return Err(ImageError::Decode("apng: canvas too large".into()));
@@ -85,7 +74,6 @@ impl ApngDecoder {
         let canvas_w = self.width;
         let canvas_h = self.height;
 
-        // Visible row/col span after clamping to the canvas.
         let copy_h = h.min(canvas_h.saturating_sub(y));
         let copy_w = w.min(canvas_w.saturating_sub(x));
         if copy_h == 0 || copy_w == 0 {
@@ -114,8 +102,7 @@ impl ApngDecoder {
             DisposeOp::None => {}
             DisposeOp::Background => {
                 let (x, y, w, h) = (fc.x_offset, fc.y_offset, fc.width, fc.height);
-                // x/y beyond the canvas → nothing to clear (defensive; the
-                // `png` crate rejects this, but belt-and-suspenders).
+                // Out-of-canvas disposal coordinates leave the canvas unchanged.
                 let Some(remaining_w) = self.width.checked_sub(x) else {
                     return;
                 };
@@ -156,8 +143,6 @@ impl ApngDecoder {
             .frame_control
             .ok_or_else(|| ImageError::Decode("apng: missing frame control".into()))?;
 
-        // Convert sub-frame to RGBA if needed. `png` gives us raw bytes in
-        // the source color type; coerce to RGBA8.
         let color = info.color_type;
         let bit_depth = info.bit_depth;
         if bit_depth != png::BitDepth::Eight {
@@ -173,17 +158,15 @@ impl ApngDecoder {
             &mut self.rgba_sub,
         )?;
 
-        // Save "before" state for PREVIOUS disposal.
+        // PREVIOUS disposal needs the canvas before this frame is composited.
         if matches!(frame_control.dispose_op, DisposeOp::Previous) {
             self.previous_canvas.copy_from_slice(&self.canvas);
         }
 
-        // Borrow rgba_sub immutably for composite. We re-borrow self.canvas
-        // mutably inside composite_frame — split-borrow via a local would
-        // help, but we route through composite_frame for clarity.
+        // Temporarily move the scratch buffer to borrow the compositor mutably.
         let rgba_sub = std::mem::take(&mut self.rgba_sub);
         self.composite_frame(frame_control, &rgba_sub);
-        self.rgba_sub = rgba_sub; // hand the buffer back
+        self.rgba_sub = rgba_sub;
 
         let delay_ms = {
             let num = f32::from(frame_control.delay_num);
@@ -200,8 +183,7 @@ impl ApngDecoder {
             }
         };
 
-        // Canvas is needed by the next frame's disposal/composite, so copy
-        // (don't move) it out.
+        // Clone because subsequent frames still need the working canvas.
         let frame = AnimatedFrame {
             rgba: self.canvas.clone(),
             width: self.width,
@@ -209,8 +191,7 @@ impl ApngDecoder {
             delay_ms,
         };
 
-        // Apply disposal for the NEXT frame (acts on self.canvas after we
-        // snapshotted the current frame into `frame.rgba`).
+        // Snapshot before disposal so the emitted frame retains its pixels.
         self.apply_dispose(frame_control);
 
         self.frames_read += 1;
@@ -218,8 +199,7 @@ impl ApngDecoder {
     }
 }
 
-/// Alpha-blend `src` (RGBA) over `dst` (RGBA), per pixel. Hot inner loop for
-/// `BlendOp::Over` — short-circuits the common α=255 (full overwrite) case.
+/// Composites straight-alpha RGBA `src` over `dst`; slice lengths must match.
 fn composite_row_over(dst: &mut [u8], src: &[u8]) {
     debug_assert_eq!(dst.len(), src.len());
     debug_assert!(dst.len().is_multiple_of(4));
@@ -237,9 +217,8 @@ fn composite_row_over(dst: &mut [u8], src: &[u8]) {
         if sa == 0 {
             continue;
         }
-        // Straight-alpha OVER. Weight destination RGB by its alpha too;
-        // otherwise a half-transparent pixel over transparent black darkens
-        // twice when the result is later flattened for an LED display.
+        // Weight destination RGB by destination alpha to avoid darkening translucent
+        // pixels twice when the composited canvas is flattened over black.
         let sa = u32::from(sa);
         let da = u32::from(d[3]);
         let inv = 255 - sa;
@@ -252,9 +231,8 @@ fn composite_row_over(dst: &mut [u8], src: &[u8]) {
     }
 }
 
-/// Expand an arbitrary PNG sub-frame buffer to RGBA8 into `out`. APNG
-/// sub-frames can be any of the PNG color types; the `png` crate decodes them
-/// in their native form. `out` is resized to `n_pixels * 4` bytes.
+/// Expands transformed eight-bit PNG samples to `n_pixels * 4` RGBA bytes.
+/// Indexed samples must already be expanded by the PNG reader.
 fn expand_to_rgba8(
     buf: &[u8],
     color: ColorType,

--- a/src/image/animated/cache.rs
+++ b/src/image/animated/cache.rs
@@ -1,8 +1,5 @@
-//! LRU frame cache keyed by URL + stream options, bounded by MB.
-//!
-//! Only activates for looping animations with at least `frame_cache_min_frames`
-//! frames — short or one-shot sequences aren't worth the memory. Shared across
-//! streams so two clients watching the same GIF pay decode cost once.
+//! Memory-bounded LRU cache of rendered animation frames, shared across streams.
+//! The dispatcher caches looping sequences that meet the minimum frame count.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -21,7 +18,7 @@ pub struct CacheKey {
 
 #[derive(Debug, Clone)]
 pub struct CachedSequence {
-    /// Pre-rendered RGB888 frames at the target size + delay per frame.
+    /// Rendered RGB888 frames at target size, paired with delays in milliseconds.
     pub frames: Vec<(Bytes, f32)>,
     bytes: usize,
 }
@@ -64,11 +61,10 @@ impl FrameCache {
         self.is_enabled() && looping && frame_count >= self.min_frames
     }
 
-    /// Look up cached frames; touches LRU on hit.
+    /// Looks up cached frames; touches LRU on hit.
     pub fn get(&self, key: &CacheKey) -> Option<Arc<CachedSequence>> {
         let mut inner = self.inner.lock();
         let seq = inner.entries.get(key).cloned()?;
-        // Move key to MRU position.
         if let Some(pos) = inner.lru.iter().position(|k| k == key) {
             let k = inner.lru.remove(pos);
             inner.lru.push(k);
@@ -76,7 +72,7 @@ impl FrameCache {
         Some(seq)
     }
 
-    /// Insert a sequence. Evicts LRU entries until the new total fits under
+    /// Inserts a sequence. Evicts LRU entries until the new total fits under
     /// `max_bytes`. If `seq.bytes > max_bytes` the insert is refused.
     pub fn insert(&self, key: CacheKey, seq: CachedSequence) -> Option<Arc<CachedSequence>> {
         if seq.bytes > self.max_bytes {
@@ -85,7 +81,6 @@ impl FrameCache {
         let arc = Arc::new(seq);
         let mut inner = self.inner.lock();
 
-        // If this key is already cached, evict the old entry first.
         if let Some(old) = inner.entries.remove(&key) {
             inner.bytes = inner.bytes.saturating_sub(old.bytes);
             if let Some(pos) = inner.lru.iter().position(|k| k == &key) {
@@ -162,7 +157,7 @@ mod tests {
         let k3 = key("c");
         c.insert(k1.clone(), seq(1024));
         c.insert(k2.clone(), seq(1024));
-        let _ = c.get(&k1); // k1 now MRU
+        let _ = c.get(&k1); // touch k1 to protect it from eviction
         c.insert(k3.clone(), seq(1024)); // evicts k2, not k1
         assert!(c.get(&k1).is_some());
         assert!(c.get(&k2).is_none());

--- a/src/image/animated/dispatch.rs
+++ b/src/image/animated/dispatch.rs
@@ -1,5 +1,4 @@
-//! Pick the right decoder by format sniff, composite all frames through the
-//! still-image pipeline, populate the frame cache, return the sequence.
+//! Decodes animations into target-sized RGB888 sequences with optional caching.
 
 use std::sync::Arc;
 
@@ -24,9 +23,7 @@ enum Kind {
     SinglePng,
 }
 
-/// Sniff the format from the leading bytes. Indicates whether the buffer is
-/// an animated container we handle, or a single-frame format to fall back
-/// to the still-image pipeline.
+/// Identifies GIF, APNG, WebP or static PNG from the container bytes.
 fn sniff(data: &[u8]) -> Option<Kind> {
     if data.starts_with(b"GIF87a") || data.starts_with(b"GIF89a") {
         return Some(Kind::Gif);
@@ -58,9 +55,7 @@ pub fn is_animated(data: &[u8]) -> bool {
     matches!(sniff(data), Some(Kind::Gif | Kind::Apng | Kind::Webp))
 }
 
-/// Cap on decoded frames per animated source. A 50 MB file can claim
-/// millions of tiny frames; we refuse to composite past this count so the
-/// cache + pipeline can't be tricked into eating the heap.
+/// Limits frame-count amplification from small compressed animations.
 const MAX_ANIMATED_FRAMES: usize = 10_000;
 
 #[derive(Debug)]
@@ -76,8 +71,7 @@ pub struct AnimatedDispatchParams<'a> {
     pub r#loop: bool,
 }
 
-/// Load, decode, composite, and cache all frames of an animated source.
-/// Returns an Arc-shared sequence ready to emit at native cadence.
+/// Returns all rendered frames, reusing or populating the cache when eligible.
 pub fn dispatch(
     data: Vec<u8>,
     params: &AnimatedDispatchParams,
@@ -107,8 +101,7 @@ pub fn dispatch(
         }
     };
 
-    // Composite each frame through the still-image pipeline so the cached
-    // frames are at target size + RGB888.
+    // Use the static pipeline so animated and still frames share rendering settings.
     let mut composed: Vec<(Bytes, f32)> = Vec::new();
     while let Some(AnimatedFrame {
         rgba,

--- a/src/image/animated/gif.rs
+++ b/src/image/animated/gif.rs
@@ -1,8 +1,4 @@
-//! GIF decoder with disposal handling via `gif` + `gif-dispose`.
-//!
-//! `gif-dispose` 6.x owns the canvas state and handles all three disposal
-//! methods (NONE / BACKGROUND / PREVIOUS) — we just feed it decoded frames
-//! and it returns the fully-composited canvas.
+//! GIF decoding through `gif-dispose`, which owns the canvas and disposal state.
 
 use gif::Decoder;
 use gif_dispose::Screen;
@@ -35,8 +31,7 @@ impl GifDecoder {
             Ok(None) => return Ok(None),
             Err(e) => return Err(ImageError::Decode(format!("gif frame: {e}"))),
         };
-        // GIF delay is in centiseconds; clamp to MIN_DELAY_MS so downstream
-        // pacing never sees a sub-frame interval.
+        // GIF stores delays in centiseconds.
         let delay_ms = {
             let raw = f32::from(frame.delay) * 10.0;
             if raw <= 0.0 {
@@ -52,9 +47,7 @@ impl GifDecoder {
         let pixels = self.screen.pixels_rgba();
         let (w, h) = (pixels.width() as u32, pixels.height() as u32);
 
-        // `pixels_rgba()` returns `ImgVec<RGBA8>`; flatten to `&[u8]` via
-        // bytemuck since `RGBA8` is `#[repr(C)]` Pod. `Screen` owns its
-        // canvas — we have to copy to hand the caller an owned buffer.
+        // `Screen` owns the canvas; copying gives the caller independent frame pixels.
         let rgba_bytes: &[u8] = bytemuck::cast_slice(pixels.buf());
         Ok(Some(AnimatedFrame {
             rgba: rgba_bytes.to_vec(),

--- a/src/image/animated/mod.rs
+++ b/src/image/animated/mod.rs
@@ -1,12 +1,5 @@
-//! Animated image compositor.
-//!
-//! Three formats live here: GIF (via `gif` + `gif-dispose`), APNG (via `png`
-//! with a manual disposal/blend compositor), and animated WebP (via
-//! `image-webp` on git `main` for the post-#179 fixes).
-//!
-//! Each format decoder produces a stream of `AnimatedFrame` — fully
-//! composited RGBA + per-frame duration — that the dispatcher runs through
-//! the still-image pipeline and caches as RGB888.
+//! GIF, APNG and WebP decoders return composited RGBA frames and durations.
+//! The dispatcher resizes them through the image pipeline and caches RGB888.
 
 pub mod apng;
 pub mod cache;
@@ -14,16 +7,14 @@ pub mod dispatch;
 pub mod gif;
 pub mod webp;
 
-/// One fully-composited animation frame. The buffer is owned (as `Vec<u8>`,
-/// not `Bytes`) so the dispatcher can hand it directly to the still-image
-/// pipeline without an extra copy.
+/// Composited animation frame owned by the image pipeline to avoid an extra copy.
 #[derive(Debug, Clone)]
 pub struct AnimatedFrame {
     /// RGBA canvas at the animation's natural size.
     pub rgba: Vec<u8>,
     pub width: u32,
     pub height: u32,
-    /// Display duration for this frame.
+    /// Display duration in milliseconds.
     pub delay_ms: f32,
 }
 
@@ -33,11 +24,7 @@ pub const MIN_DELAY_MS: f32 = 10.0;
 /// Default when the source reports zero/unknown duration.
 pub const DEFAULT_DELAY_MS: f32 = 100.0;
 
-/// Concrete animated-decoder enum — hot-path dispatch per `rust.md` §3.
-///
-/// Each variant's inner state is heap-allocated via `Box`: the discriminant
-/// lives on the stack, but the backing canvas buffers (~megabytes for
-/// anything wider than a postage stamp) stay on the heap.
+/// Format-specific decoders with heap-allocated decoder state.
 pub enum AnimatedDecoder {
     Gif(Box<gif::GifDecoder>),
     Apng(Box<apng::ApngDecoder>),

--- a/src/image/animated/webp.rs
+++ b/src/image/animated/webp.rs
@@ -55,8 +55,7 @@ impl WebpDecoder {
     pub fn next_frame(&mut self) -> Result<Option<AnimatedFrame>, ImageError> {
         let Some(limit) = self.frame_count else {
             if self.frames_read == 0 {
-                // Single-frame WebP decoded through the animated path —
-                // read_image once and return.
+                // The animated dispatcher also routes static WebP through this decoder.
                 self.decoder.read_image(&mut self.buf).map_err(webp_err)?;
                 self.frames_read = 1;
                 return Ok(Some(AnimatedFrame {
@@ -92,9 +91,8 @@ impl WebpDecoder {
         }))
     }
 
-    /// Hand the current canvas buffer to the caller and replace it with a
-    /// fresh allocation. `read_frame` / `read_image` fully overwrite the
-    /// buffer on the next call, so we don't need to preserve its contents.
+    /// Returns owned RGBA pixels. Alpha buffers can be moved because the decoder
+    /// overwrites them; opaque RGB buffers require expansion.
     fn take_buf(&mut self) -> Vec<u8> {
         if self.decoder.has_alpha() {
             let cap = self.buf.len();

--- a/src/image/decode.rs
+++ b/src/image/decode.rs
@@ -1,7 +1,4 @@
-//! Fetch + decode image bytes.
-//!
-//! Size caps: >50 MB rejected pre-decode; ≤500 KB held in memory, larger
-//! payloads spill to a temp file.
+//! Static image decoding with input, dimension and allocation limits.
 
 use crate::error::{ImageError, MediaError};
 
@@ -9,8 +6,7 @@ pub const MAX_SIZE_LIMIT: usize = 50 * 1024 * 1024;
 pub const MEMORY_THRESHOLD: usize = 500 * 1024;
 pub const MIN_DELAY_MS: f32 = 10.0;
 
-/// Upper bound on decoded image dimensions. Anything larger is refused to
-/// prevent decompression-bomb blowups in the decoder.
+/// Dimension cap limits decompression-bomb allocations.
 pub const MAX_DECODE_DIM: u32 = 8192;
 
 /// Upper bound on decoder scratch allocation.
@@ -26,8 +22,8 @@ pub struct DecodedImage {
     pub icc_profile: Option<Vec<u8>>,
 }
 
-/// Decode a byte buffer into RGBA. Returns an [`ImageError`] on malformed
-/// data; the caller is responsible for size-capping upstream.
+/// Decodes bounded image bytes to RGBA8, retaining PNG or JPEG ICC metadata.
+/// Returns an error for malformed data or exceeded input/decoder limits.
 pub fn decode_bytes(data: &[u8], source_url: &str) -> Result<DecodedImage, ImageError> {
     if data.len() > MAX_SIZE_LIMIT {
         return Err(ImageError::DecompressionBomb {
@@ -48,8 +44,7 @@ pub fn decode_bytes(data: &[u8], source_url: &str) -> Result<DecodedImage, Image
     limits.max_image_height = Some(MAX_DECODE_DIM);
     limits.max_alloc = Some(MAX_DECODE_ALLOC_BYTES);
     reader.limits(limits);
-    // Extract ICC profile via a per-format decoder pass (the generic
-    // `ImageReader` drops it). Currently supported: PNG, JPEG, WebP.
+    // A separate decoder preserves ICC metadata that `ImageReader` discards.
     let icc_profile = icc_profile_from_bytes(data);
     let img = reader.decode().map_err(|e| ImageError::Decode(e.to_string()))?;
     let rgba = img.to_rgba8();
@@ -64,7 +59,6 @@ pub fn decode_bytes(data: &[u8], source_url: &str) -> Result<DecodedImage, Image
 
 fn icc_profile_from_bytes(data: &[u8]) -> Option<Vec<u8>> {
     use image::{ImageDecoder, codecs::jpeg::JpegDecoder, codecs::png::PngDecoder};
-    // PNG: iCCP chunk. Try the png decoder first when the signature matches.
     if data.starts_with(&[0x89, b'P', b'N', b'G']) {
         if let Ok(mut d) = PngDecoder::new(std::io::Cursor::new(data))
             && let Ok(Some(p)) = d.icc_profile()
@@ -73,7 +67,7 @@ fn icc_profile_from_bytes(data: &[u8]) -> Option<Vec<u8>> {
         }
         return None;
     }
-    // JPEG: APP2 markers joined from multi-segment `ICC_PROFILE`.
+    // JPEG ICC profiles can span multiple APP2 markers.
     if data.starts_with(&[0xFF, 0xD8]) {
         if let Ok(mut d) = JpegDecoder::new(std::io::Cursor::new(data))
             && let Ok(Some(p)) = d.icc_profile()

--- a/src/image/dispatch.rs
+++ b/src/image/dispatch.rs
@@ -1,8 +1,4 @@
-//! Image source dispatch: fetch → sniff animated-vs-static → build `FrameSource`.
-//!
-//! The orchestrator hands this module the resolved `StreamFields`; we own
-//! fetching, format detection, decoding, compositing, and cache population
-//! so the orchestrator's `build_source` stays a three-way router.
+//! Fetches images, selects static or animated decoding, and builds a frame source.
 
 use crate::Config;
 use crate::control::fields::StreamFields;
@@ -44,7 +40,7 @@ pub async fn build_image_source(
             source_url: &fields.source,
             r#loop: fields.r#loop,
         };
-        // CPU-bound inline — swap to `spawn_blocking` if runtime starvation shows up.
+        // Decoding runs inline on the async task.
         let seq = animated::dispatch(bytes, &params, frame_cache).map_err(StreamError::Image)?;
         return Ok(FrameSource::Animated(AnimatedSource {
             frames: seq,

--- a/src/image/gamma.rs
+++ b/src/image/gamma.rs
@@ -1,12 +1,4 @@
-//! sRGB ↔ linear-light LUTs (gamma-aware resize).
-//!
-//! Two LUTs computed once at startup:
-//!
-//! - `SRGB_TO_LINEAR_U16`: 256 → u16, sRGB-encoded u8 → 16-bit linear.
-//! - `LINEAR_TO_SRGB_U8`:  65536 → u8, 16-bit linear → sRGB-encoded u8.
-//!
-//! Both use the piecewise sRGB curve — inputs above 0.04045 go through
-//! `((x + 0.055) / 1.055) ^ 2.4`, below use the linear `x / 12.92` region.
+//! Lazy lookup tables convert between sRGB u8 and linear-light u16 values.
 
 use std::sync::LazyLock;
 
@@ -41,7 +33,7 @@ pub static LINEAR_TO_SRGB_U8: LazyLock<Box<[u8; 65536]>> = LazyLock::new(|| {
     lut
 });
 
-/// Convert a slice of sRGB u8 into linear u16 in-place-ish via LUT.
+/// Writes linear-light values to an output slice of matching length.
 pub fn srgb_to_linear(input: &[u8], output: &mut [u16]) {
     debug_assert_eq!(input.len(), output.len());
     for (i, &x) in input.iter().enumerate() {
@@ -49,7 +41,7 @@ pub fn srgb_to_linear(input: &[u8], output: &mut [u16]) {
     }
 }
 
-/// Convert a slice of linear u16 into sRGB u8 via LUT.
+/// Writes sRGB values to an output slice of matching length.
 pub fn linear_to_srgb(input: &[u16], output: &mut [u8]) {
     debug_assert_eq!(input.len(), output.len());
     for (i, &y) in input.iter().enumerate() {

--- a/src/image/icc.rs
+++ b/src/image/icc.rs
@@ -1,15 +1,13 @@
-//! ICC profile → sRGB conversion via `lcms2`.
-//!
-//! Uses relative colorimetric intent (PIL's default) and degrades gracefully
-//! to "do nothing" when the profile is missing/invalid/already-sRGB.
+//! ICC conversion to sRGB with relative colorimetric intent.
+//! `to_srgb_inplace_soft` logs conversion failures and leaves pixels unchanged.
 
 use lcms2::{Intent, PixelFormat, Profile, Transform};
 use tracing::{debug, warn};
 
 use crate::error::ImageError;
 
-/// Convert an RGBA buffer from its embedded ICC profile to sRGB. Mutates
-/// the buffer in place. Returns `Ok(false)` if no conversion was needed.
+/// Converts RGBA pixels to sRGB in place. Returns `Ok(false)` for absent
+/// profiles or descriptions containing "srgb"; invalid profiles return an error.
 pub fn to_srgb_inplace(rgba: &mut [u8], icc: Option<&[u8]>) -> Result<bool, ImageError> {
     let Some(profile_bytes) = icc else {
         return Ok(false);
@@ -19,7 +17,6 @@ pub fn to_srgb_inplace(rgba: &mut [u8], icc: Option<&[u8]>) -> Result<bool, Imag
         .map_err(|e| ImageError::Icc(format!("load embedded profile: {e}")))?;
     let srgb = Profile::new_srgb();
 
-    // If the source claims to be sRGB, skip.
     if let Some(name) = source.info(lcms2::InfoType::Description, lcms2::Locale::none())
         && name.to_ascii_lowercase().contains("srgb")
     {
@@ -27,8 +24,6 @@ pub fn to_srgb_inplace(rgba: &mut [u8], icc: Option<&[u8]>) -> Result<bool, Imag
         return Ok(false);
     }
 
-    // One pixel = `[u8; 4]`. The transform runs the 4-channel input/output
-    // through RGBA_8 → RGBA_8.
     let transform: Transform<[u8; 4], [u8; 4]> = Transform::new(
         &source,
         PixelFormat::RGBA_8,
@@ -38,17 +33,13 @@ pub fn to_srgb_inplace(rgba: &mut [u8], icc: Option<&[u8]>) -> Result<bool, Imag
     )
     .map_err(|e| ImageError::Icc(format!("build transform: {e}")))?;
 
-    // In-place transform over the whole buffer at once.
     let pixel_count = rgba.len() / 4;
-    // SAFETY: `rgba` is `len = pixel_count * 4`; `[u8; 4]` has the same
-    // layout and alignment as 4×u8, so reinterpreting is sound.
     let pixels: &mut [[u8; 4]] = bytemuck::cast_slice_mut(&mut rgba[..pixel_count * 4]);
     transform.transform_in_place(pixels);
     Ok(true)
 }
 
-/// Quiet variant — logs warnings instead of propagating errors. A broken
-/// profile shouldn't take down the stream.
+/// Logs ICC conversion errors so an invalid profile does not stop playback.
 pub fn to_srgb_inplace_soft(rgba: &mut [u8], icc: Option<&[u8]>) -> bool {
     match to_srgb_inplace(rgba, icc) {
         Ok(applied) => applied,

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -1,4 +1,4 @@
-//! Static + animated image pipeline.
+//! Static and animated image processing.
 
 pub mod animated;
 pub mod decode;

--- a/src/image/palette.rs
+++ b/src/image/palette.rs
@@ -1,8 +1,4 @@
-//! Palette-preserving resize for indexed / transparency-index images.
-//!
-//! Resize the *indices* with nearest-neighbor, then map back through the
-//! palette. Keeps pixel-art LED content crisp and avoids the quantization
-//! losses you'd get from resampling RGB.
+//! Nearest-neighbor resizing of palette indices preserves pixel-art colors.
 
 use crate::error::ImageError;
 
@@ -16,11 +12,8 @@ pub struct Paletted {
 }
 
 impl Paletted {
-    /// Resize indices with nearest-neighbor, then expand through the palette.
-    ///
-    /// Transparent pixels blend onto a black background (LED default).
-    /// Source-x and source-y nearest-neighbor maps are precomputed once each
-    /// — the inner loop is two indexed loads and three byte writes per pixel.
+    /// Resizes palette indices and expands to RGB888 over black.
+    /// The transparency index maps to black.
     pub fn resize_to_rgb888(&self, dst_w: u32, dst_h: u32) -> Result<Vec<u8>, ImageError> {
         if dst_w == 0 || dst_h == 0 {
             return Err(ImageError::Resize("dst dimensions zero".into()));
@@ -36,8 +29,7 @@ impl Paletted {
             .map(|y| (((y as f64 + 0.5) * sh / dst_h as f64).floor() as u32).min(last_y))
             .collect();
 
-        // Pre-expand the palette to RGB888 with the transparency index
-        // collapsed to black, so the inner loop has no per-pixel branches.
+        // Pre-expanding the palette avoids per-pixel transparency branches.
         let palette_size = self.palette_rgb.len().max(1);
         let mut palette_rgb888 = vec![0u8; palette_size * 3];
         for (i, rgb) in self.palette_rgb.iter().enumerate() {

--- a/src/image/pipeline.rs
+++ b/src/image/pipeline.rs
@@ -1,4 +1,4 @@
-//! End-to-end static image pipeline: decoded RGBA → target RGB888.
+//! Static image processing from decoded RGBA to target-sized RGB888.
 
 use crate::control::fields::Fit;
 use crate::error::ImageError;
@@ -20,8 +20,7 @@ pub struct PipelineParams {
 pub struct ImagePipeline;
 
 impl ImagePipeline {
-    /// Run the pipeline: ICC → resize (in linear light when gamma-aware) →
-    /// fit → unsharp → RGB888 output.
+    /// Applies ICC conversion, resize, fit and unsharp masking, returning RGB888.
     pub fn run(mut image: DecodedImage, params: &PipelineParams) -> Result<Vec<u8>, ImageError> {
         if params.color_correction {
             icc::to_srgb_inplace_soft(&mut image.rgba, image.icc_profile.as_deref());
@@ -73,15 +72,8 @@ impl ImagePipeline {
     }
 }
 
-/// Gamma-aware resize: pack the RGBA source as a single U16x4 image with R/G/B
-/// in linear light and alpha widened (`a * 257`), resize once via
-/// `fast_image_resize`, then narrow back to RGB888 + sRGB alpha.
-///
-/// Single-pass resize replaces the previous four separate single-channel
-/// resizes (3× u16 + 1× u8). Alpha rounds slightly differently — the u16
-/// widen/narrow round-trips through the resize at one extra bit of precision,
-/// so the output may differ by ±1 in alpha. R/G/B remain bit-identical for
-/// the convolution given the same algorithm.
+/// Resizes RGBA through one U16x4 buffer, with RGB in linear light and alpha
+/// widened by 257. Returns sRGB-encoded RGBA8 with rounded alpha.
 fn resize_rgba_gamma_aware(
     src: &[u8],
     src_w: u32,
@@ -98,7 +90,7 @@ fn resize_rgba_gamma_aware(
         q[0] = gamma::SRGB_TO_LINEAR_U16[px[0] as usize];
         q[1] = gamma::SRGB_TO_LINEAR_U16[px[1] as usize];
         q[2] = gamma::SRGB_TO_LINEAR_U16[px[2] as usize];
-        q[3] = u16::from(px[3]) * 257; // [0..255] → [0..65535]
+        q[3] = u16::from(px[3]) * 257; // [0..255] -> [0..65535]
     }
 
     let dst_u16 = resize::resize_u16x4(&src_u16, src_w, src_h, dst_w, dst_h, method)?;
@@ -110,7 +102,7 @@ fn resize_rgba_gamma_aware(
         out[i * 4] = gamma::LINEAR_TO_SRGB_U8[p[0] as usize];
         out[i * 4 + 1] = gamma::LINEAR_TO_SRGB_U8[p[1] as usize];
         out[i * 4 + 2] = gamma::LINEAR_TO_SRGB_U8[p[2] as usize];
-        // narrow u16 → u8: `(v + 128) / 257` is the exact inverse of `*257`.
+        // Rounded division by 257 preserves the alpha widening round trip.
         out[i * 4 + 3] = ((u32::from(p[3]) + 128) / 257) as u8;
     }
     Ok(out)

--- a/src/image/resize.rs
+++ b/src/image/resize.rs
@@ -1,7 +1,4 @@
-//! Image resize with `fast_image_resize` 6.x.
-//!
-//! Implements LANCZOS/BICUBIC/BILINEAR/BOX/NEAREST plus AUTO (scale-dependent,
-//! integer-ratio aware).
+//! Image resizing and black-background compositing with `fast_image_resize`.
 
 use fast_image_resize::PixelType;
 use fast_image_resize::images::{Image, ImageRef};
@@ -44,11 +41,8 @@ impl ResampleMethod {
     }
 }
 
-/// Pick the resize algorithm for AUTO based on scale + integer-ratio detection.
-///
-/// Upscales stay crisp via Nearest; modest downscales with a near-integer
-/// pixel ratio also pick Nearest so pixel-art survives (LED-art friendly);
-/// everything else uses Box for anti-aliased downscales.
+/// Selects Nearest for upscaling and near-integer downscales of at most 2x
+/// to preserve pixel-art edges. Other downscales use Box filtering.
 fn auto_alg(src_w: u32, src_h: u32, dst_w: u32, dst_h: u32) -> ResizeAlg {
     if src_w == 0 || src_h == 0 {
         return ResizeAlg::Nearest;
@@ -79,10 +73,8 @@ fn alg_for(method: ResampleMethod, src_w: u32, src_h: u32, dst_w: u32, dst_h: u3
     }
 }
 
-/// Compute `(new_w, new_h)` for a given fit mode and target size.
-///
-/// `Pad` and `Cover` scale to fit / fill respectively. `Auto` scales directly
-/// when aspect ratios match (within 1%), else falls back to `Pad`.
+/// Computes dimensions for fit or fill. `Auto` uses the target dimensions
+/// when the absolute aspect-ratio difference is below 0.01, otherwise `Pad`.
 pub fn compute_fit_size(src_w: u32, src_h: u32, dst_w: u32, dst_h: u32, fit: Fit) -> (u32, u32) {
     if src_w == 0 || src_h == 0 {
         return (dst_w.max(1), dst_h.max(1));
@@ -106,7 +98,7 @@ pub fn compute_fit_size(src_w: u32, src_h: u32, dst_w: u32, dst_h: u32, fit: Fit
     (new_w, new_h)
 }
 
-/// Resize an RGBA source into a new RGBA buffer at `(dst_w, dst_h)`.
+/// Resizes an RGBA source into a new RGBA buffer at `(dst_w, dst_h)`.
 pub fn resize_rgba(
     src: &[u8],
     src_w: u32,
@@ -127,8 +119,7 @@ pub fn resize_rgba(
     Ok(dst_image.into_vec())
 }
 
-/// Resize a 4-channel u16-per-channel image. Used by the gamma-aware path —
-/// one resize call instead of four single-channel passes.
+/// Resizes four-channel u16 data for the gamma-aware pipeline.
 pub fn resize_u16x4(
     src: &[u16],
     src_w: u32,
@@ -158,14 +149,8 @@ pub struct CompositePlan {
     pub target: (u32, u32),
 }
 
-/// Composite an RGBA source onto a black `target` canvas. `src_off` picks the
-/// top-left corner in the source (positive for center-crop / `Cover`);
-/// `dst_off` picks where in the target canvas the region lands (positive for
-/// letterbox / `Pad`).
-///
-/// Walks row-by-row to avoid per-pixel index math, with a fast path when the
-/// inner rect already fills the target (no letterbox margins, no center-crop
-/// offsets) — the common case after a `compute_fit_size` resize.
+/// Composites RGBA onto black RGB888. `src_off` selects the source rectangle;
+/// `dst_off` positions it in the target. Both rectangles must be in bounds.
 pub fn composite_rgba_to_rgb888(rgba: &[u8], plan: &CompositePlan) -> Vec<u8> {
     let (target_w, target_h) = plan.target;
     let (copy_w, copy_h) = plan.copy;
@@ -187,8 +172,7 @@ pub fn composite_rgba_to_rgb888(rgba: &[u8], plan: &CompositePlan) -> Vec<u8> {
     out
 }
 
-/// Walk one row of RGBA → RGB888, blending each pixel against a black
-/// background. Hot path for opaque sources is a 3-byte copy per pixel.
+/// Flattens straight-alpha RGBA over black; opaque pixels retain their RGB.
 fn composite_row_over_black(src: &[u8], dst: &mut [u8]) {
     debug_assert_eq!(src.len() % 4, 0);
     debug_assert_eq!(dst.len(), src.len() / 4 * 3);
@@ -216,7 +200,7 @@ fn composite_row_over_black(src: &[u8], dst: &mut [u8]) {
     }
 }
 
-/// Letterbox a smaller RGBA image onto a `target_w × target_h` black canvas.
+/// Letterboxes a smaller RGBA image onto a `target_w x target_h` black canvas.
 pub fn letterbox_rgba_to_rgb888(
     rgba: &[u8],
     inner_w: u32,
@@ -240,7 +224,7 @@ pub fn letterbox_rgba_to_rgb888(
     )
 }
 
-/// Center-crop a larger RGBA image into a `target_w × target_h` canvas.
+/// Center-crops a larger RGBA image into a `target_w x target_h` canvas.
 pub fn cover_rgba_to_rgb888(
     rgba: &[u8],
     inner_w: u32,

--- a/src/image/unsharp.rs
+++ b/src/image/unsharp.rs
@@ -1,16 +1,9 @@
-//! Pillow-compatible unsharp mask.
-//!
-//! Algorithm (matches Pillow's `UnsharpMask` in `ImageFilter.c`):
-//! 1. Gaussian blur of input with radius `r`.
-//! 2. For each pixel: diff = orig - blurred (per channel).
-//! 3. If |diff| < threshold, keep orig unchanged.
-//! 4. Else orig += diff * (percent / 100).
-//! 5. Clamp to [0, 255].
+//! RGB888 sharpening with a separable box blur and a per-channel threshold.
 
 #[derive(Debug, Clone)]
 pub struct UnsharpParams {
     pub radius: f32,
-    pub amount: f32, // 0.0..1.0 (Pillow's "percent" is `amount * 100`)
+    pub amount: f32, // Gain multiplier; nonpositive values disable sharpening.
     pub threshold: i32,
 }
 
@@ -20,7 +13,7 @@ pub fn unsharp_rgb888(buf: &mut [u8], width: u32, height: u32, p: &UnsharpParams
         return;
     }
     let blurred = box_blur_rgb888(buf, width, height, p.radius.max(0.1));
-    let percent = p.amount; // already 0..1
+    let percent = p.amount;
 
     for i in 0..buf.len() {
         let orig = buf[i] as i32;
@@ -34,19 +27,15 @@ pub fn unsharp_rgb888(buf: &mut [u8], width: u32, height: u32, p: &UnsharpParams
     }
 }
 
-/// 2-pass separable box blur via sliding-window running sums (O(W·H), not
-/// O(W·H·R)).
-///
-/// Output is bit-identical to the prior O(W·H·R) implementation: same window
-/// clamping at edges, same per-pixel `sum / count` truncation.
+/// Computes a separable box blur in O(width * height).
+/// Edge windows use only in-bounds pixels; each pass truncates its average.
 fn box_blur_rgb888(src: &[u8], width: u32, height: u32, radius: f32) -> Vec<u8> {
     let r = radius.round().max(1.0) as i32;
     let w = width as i32;
     let h = height as i32;
     let stride = (w as usize) * 3;
 
-    // Horizontal pass: src → tmp. We don't read tmp before writing it, so it
-    // doesn't need to be initialized from src.
+    // Every temporary pixel is written before the vertical pass reads it.
     let mut tmp = vec![0u8; src.len()];
     for y in 0..h as usize {
         let row_in = &src[y * stride..(y + 1) * stride];
@@ -54,14 +43,12 @@ fn box_blur_rgb888(src: &[u8], width: u32, height: u32, radius: f32) -> Vec<u8> 
         blur_row(row_in, row_out, w, r);
     }
 
-    // Vertical pass: tmp → out. We walk down columns; each column is a
-    // strided view into tmp, so we read with stride `stride`.
     let mut out = vec![0u8; src.len()];
     let mut sums = vec![0u32; (w as usize) * 3];
     let r_us = r as usize;
     let h_us = h as usize;
 
-    // Initialize per-column running sums for y=0: window is rows [0, r] (clamped).
+    // The first window includes rows 0 through r, clipped to the image.
     let init_end = r_us.min(h_us - 1);
     for yy in 0..=init_end {
         add_row_to_sums(&mut sums, &tmp[yy * stride..(yy + 1) * stride]);
@@ -70,8 +57,6 @@ fn box_blur_rgb888(src: &[u8], width: u32, height: u32, radius: f32) -> Vec<u8> 
 
     for y in 0..h_us {
         write_quotient_row(&sums, &mut out[y * stride..(y + 1) * stride], count);
-        // Advance window for y+1: add row (y + r + 1) if in bounds, remove
-        // row (y - r) if in bounds.
         let incoming = y as i32 + r + 1;
         if incoming < h {
             add_row_to_sums(
@@ -92,9 +77,7 @@ fn box_blur_rgb888(src: &[u8], width: u32, height: u32, radius: f32) -> Vec<u8> 
     out
 }
 
-/// Add `row`'s u8 bytes (widened to u32) into the running `sums` array,
-/// element-wise. SIMD path: 8 lanes via `wide::u32x8`. With v3 baseline this
-/// emits AVX2 `vpmovzxbd` + `vpaddd`.
+/// Adds a row to per-channel sums using eight SIMD lanes and a scalar tail.
 fn add_row_to_sums(sums: &mut [u32], row: &[u8]) {
     debug_assert_eq!(sums.len(), row.len());
     let n = sums.len();
@@ -131,7 +114,7 @@ fn add_row_to_sums(sums: &mut [u32], row: &[u8]) {
     }
 }
 
-/// Subtract `row`'s u8 bytes (widened to u32) from `sums`, element-wise.
+/// Subtracts a row from per-channel sums using eight SIMD lanes and a scalar tail.
 fn sub_row_from_sums(sums: &mut [u32], row: &[u8]) {
     debug_assert_eq!(sums.len(), row.len());
     let n = sums.len();
@@ -168,9 +151,7 @@ fn sub_row_from_sums(sums: &mut [u32], row: &[u8]) {
     }
 }
 
-/// Write `(sums[i] / count) as u8` to `row_out`. Scalar — `wide` has no
-/// integer divide, and the compiler with v3 still vectorizes the unsigned
-/// division-by-variable as a magic-multiply sequence per lane group.
+/// Writes truncated per-channel averages; `wide` has no integer division.
 fn write_quotient_row(sums: &[u32], row_out: &mut [u8], count: u32) {
     debug_assert_eq!(sums.len(), row_out.len());
     for (s, r) in sums.iter().zip(row_out.iter_mut()) {
@@ -178,7 +159,7 @@ fn write_quotient_row(sums: &[u32], row_out: &mut [u8], count: u32) {
     }
 }
 
-/// Blur one row with a 1-D sliding window of half-width `r`, edge-clamped.
+/// Blurs one row with a 1-D sliding window of half-width `r`, edge-clamped.
 fn blur_row(row_in: &[u8], row_out: &mut [u8], w: i32, r: i32) {
     let w_us = w as usize;
     let r_us = r as usize;
@@ -218,7 +199,7 @@ fn blur_row(row_in: &[u8], row_out: &mut [u8], w: i32, r: i32) {
 mod tests {
     use super::*;
 
-    /// Reference implementation (the pre-sliding-window version) for parity.
+    /// Direct window summation provides an independent blur reference.
     fn box_blur_naive(src: &[u8], width: u32, height: u32, radius: f32) -> Vec<u8> {
         let mut tmp = src.to_vec();
         let r = radius.round().max(1.0) as i32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
-// Pedantic / nursery stay opt-in per-module (see rust.md §Pre-commit).
-// The CI gate uses `-D warnings` so those groups must not fire by default.
+//! Media decoding and WebSocket-controlled DDP streaming.
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 pub mod api;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use media_proxy::{Config, Result, api, telemetry};
 use tracing::{info, warn};
 
 #[derive(Debug, Parser)]
-#[command(name = "media-proxy", version, about = "Media proxy → DDP for LED displays")]
+#[command(name = "media-proxy", version, about = "Streams media to displays over DDP")]
 struct Cli {
     #[arg(long, default_value = "0.0.0.0")]
     host: IpAddr,
@@ -42,7 +42,7 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-/// Resolve when the process receives SIGINT (Ctrl-C) or, on Unix, SIGTERM.
+/// Waits for SIGINT or, on Unix, SIGTERM.
 async fn shutdown_signal() {
     let ctrl_c = async {
         if let Err(e) = tokio::signal::ctrl_c().await {

--- a/src/output/ddp/packet.rs
+++ b/src/output/ddp/packet.rs
@@ -2,9 +2,9 @@
 //!
 //! Header layout (big-endian, 10 bytes total):
 //! ```text
-//! offset 0: flags    u8   0x40 = header present, 0x01 = PUSH (end-of-frame)
+//! offset 0: flags    u8   0x40 = version 1, 0x01 = PUSH (end-of-frame)
 //! offset 1: seq      u8   sequence 1..=15 (never 0, never >15)
-//! offset 2: cfg      u8   pixel config — 0x0B=RGB888, 0x61=RGB565_BE, 0x62=RGB565_LE
+//! offset 2: cfg      u8   pixel config; 0x0B=RGB888, 0x61=RGB565_BE, 0x62=RGB565_LE
 //! offset 3: out_id   u8   destination output/canvas id
 //! offset 4: offset   u32  byte offset within frame buffer
 //! offset 8: length   u16  payload bytes in this packet
@@ -54,16 +54,13 @@ impl DdpHeader {
     }
 }
 
-/// DDP sequence numbers wrap 1..=15 (0 is reserved).
-/// `next_sequence(current)` returns the next value to use.
+/// Returns the next sequence number in 1..=15; zero is reserved.
 #[inline]
 pub fn next_sequence(current: u8) -> u8 {
     (current % 15) + 1
 }
 
-/// Stateful packet encoder. Writes each packet into a caller-owned buffer so
-/// the sender can reuse a single allocation across all packets of a frame
-/// (and across frames).
+/// Encodes packets into a reusable caller-owned buffer.
 pub struct PacketEncoder<'a> {
     payload: &'a [u8],
     output_id: u8,
@@ -83,17 +80,13 @@ impl<'a> PacketEncoder<'a> {
         }
     }
 
-    /// Sequence value the next emitted packet would carry. After the last
-    /// packet has been emitted, this is the sequence the *next* frame should
-    /// start with.
+    /// Returns the sequence to use for the next packet, including across frame boundaries.
     pub fn current_seq(&self) -> u8 {
         self.seq
     }
 
-    /// Write the next packet into `buf` (cleared first). Returns `Some(len)`
-    /// where `len` is the bytes written to `buf`, or `None` when the payload
-    /// has been fully drained. `buf` must have capacity
-    /// `DDP_HEADER_LEN + DDP_MAX_DATA`.
+    /// Clears `buf` and writes the next packet, returning its length or `None`
+    /// when exhausted. Preallocating header plus maximum payload avoids growth.
     pub fn encode_next(&mut self, buf: &mut BytesMut) -> Option<usize> {
         if self.offset >= self.payload.len() {
             return None;
@@ -182,7 +175,7 @@ mod tests {
 
     #[test]
     fn multi_packet_only_last_has_push() {
-        // 1441 bytes → 2 packets (1440 + 1)
+        // 1441 bytes -> 2 packets (1440 + 1)
         let payload = vec![0u8; DDP_MAX_DATA + 1];
         let packets = collect_packets(&payload, 1);
         assert_eq!(packets.len(), 2);

--- a/src/output/ddp/pixel.rs
+++ b/src/output/ddp/pixel.rs
@@ -1,8 +1,4 @@
-//! RGB888 → RGB565 quantization (scalar + SIMD paths, identical output).
-//!
-//! Per-channel rounding follows `(c / 255) * N + 0.5`, truncated — equivalent
-//! to numpy's `(c / 255 * N + 0.5).astype(u16)`. Implemented with integer
-//! math so SIMD and scalar paths produce bit-identical output.
+//! RGB888 to RGB565 quantization with integer per-channel rounding.
 
 use crate::output::sink::PixelFormat;
 
@@ -20,8 +16,7 @@ pub fn endian_for(format: PixelFormat) -> Option<Endian> {
     }
 }
 
-/// LUT giving `r5 << 11` for each input byte. Computed at compile time from
-/// the same `(c * 31 * 2 + 255) / 510` rounding the scalar code used.
+/// Precomputed red-channel rounding and placement in RGB565.
 static LUT_R5_SHIFTED: [u16; 256] = build_r5_lut();
 static LUT_G6_SHIFTED: [u16; 256] = build_g6_lut();
 static LUT_B5: [u16; 256] = build_b5_lut();
@@ -56,12 +51,8 @@ const fn build_b5_lut() -> [u16; 256] {
     lut
 }
 
-/// RGB888 → RGB565. Input must be RGB-triplets (length multiple of 3). Any
-/// ragged tail is dropped. Returns `(len/3)*2` bytes in the chosen endianness.
-///
-/// Three 256-entry LUTs replace the per-pixel multiply/divide; the LUT path is
-/// bit-identical to the scalar `(c * N * 2 + 255) / 510` rounding the original
-/// implementation used.
+/// Converts RGB triplets to RGB565, dropping any incomplete trailing pixel.
+/// Returns `(len / 3) * 2` bytes in the requested byte order.
 pub fn rgb888_to_565(input: &[u8], endian: Endian) -> Vec<u8> {
     let n = input.len() / 3;
     let mut out = vec![0u8; n * 2];
@@ -89,11 +80,8 @@ fn convert_to(input: &[u8], out: &mut [u8], to_bytes: fn(u16) -> [u8; 2]) {
     }
 }
 
-/// Convert a frame to the requested pixel format.
-///
-/// For `Rgb888`, the input is borrowed unchanged (no copy). For the 565
-/// variants, the payload is quantized and re-packed in the requested
-/// endianness.
+/// Converts a frame to the requested format, borrowing RGB888 unchanged
+/// and allocating packed bytes for RGB565.
 pub fn encode_frame<'a>(input: &'a [u8], format: PixelFormat) -> std::borrow::Cow<'a, [u8]> {
     use std::borrow::Cow;
     match format {

--- a/src/output/ddp/registry.rs
+++ b/src/output/ddp/registry.rs
@@ -1,9 +1,5 @@
-//! DDP collision registry — actor task owning `HashMap<DdpKey, StreamId>`.
-//!
-//! The invariant: at most one active DDP stream per `(dest_ip, output_id)`.
-//! When a new `start_stream` arrives for an already-taken key, the prior
-//! stream is cancelled (via its `cancel_tx`) before the new reservation
-//! completes.
+//! Serializes DDP reservations with one owner per `(dest_ip, output_id)`.
+//! A replacement signals cancellation before receiving its reservation.
 
 use std::collections::HashMap;
 use std::net::IpAddr;
@@ -26,8 +22,7 @@ impl std::fmt::Display for DdpKey {
     }
 }
 
-/// A reservation for a DDP key. Dropping it asks the registry to release
-/// the key (the registry also treats a closed cancel channel as "gone").
+/// Requests release of this reservation on drop.
 pub struct DdpReservation {
     key: DdpKey,
     stream_id: StreamId,
@@ -77,12 +72,8 @@ impl DdpRegistry {
         Self { tx }
     }
 
-    /// Reserve a DDP key for the given stream. If another stream owns the key,
-    /// it is cancelled before this reservation is granted.
-    ///
-    /// Returns `(reservation, cancel_rx)`. The stream task watches `cancel_rx`
-    /// alongside its frame loop — it fires if a later reservation displaces
-    /// this one.
+    /// Reserves a DDP destination, signaling cancellation to its previous owner first.
+    /// The returned receiver fires when another reservation displaces this stream.
     pub async fn reserve(
         &self,
         key: DdpKey,
@@ -135,7 +126,7 @@ async fn run(mut rx: mpsc::UnboundedReceiver<RegistryMsg>) {
                 debug!(%key, %stream_id, "DDP reservation granted");
             }
             RegistryMsg::Release { key, stream_id } => {
-                // Only release if the stream_id still matches — a displaced
+                // Only release if the stream_id still matches; a displaced
                 // stream may send Release after a new one has taken over.
                 if matches!(occupied.get(&key), Some((sid, _)) if *sid == stream_id) {
                     occupied.remove(&key);
@@ -176,7 +167,6 @@ mod tests {
 
         let _res2 = reg.reserve(k, id2).await.unwrap();
 
-        // The first reservation's cancel channel should fire.
         cancel_rx.await.unwrap();
     }
 

--- a/src/output/ddp/sender.rs
+++ b/src/output/ddp/sender.rs
@@ -1,5 +1,4 @@
-//! DDP UDP sender. Owns the socket; the collision registry gates whether a
-//! sender ever comes into existence for a given key.
+//! UDP frame output with DDP address reservations managed by the registry.
 
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
@@ -21,8 +20,7 @@ use crate::output::ddp::spreading::{self, SpreadConfig};
 use crate::output::metrics::RateMeter;
 use crate::output::sink::{Frame, OutputSink, PixelFormat};
 
-/// Per-stream DDP sender. One socket, bound to an ephemeral port, shared
-/// across the stream's lifetime.
+/// Per-stream UDP sender bound to an ephemeral local port.
 pub struct DdpSender {
     socket: Arc<UdpSocket>,
     dest: SocketAddr,
@@ -33,9 +31,7 @@ pub struct DdpSender {
     pace_hz: u32,
     metrics: Option<Mutex<Metrics>>,
     seq: AtomicU8,
-    /// Reusable per-packet buffer: header + max chunk. Held under a mutex
-    /// because `OutputSink::send_frame` takes `&self`, but in practice only
-    /// one task touches it.
+    /// The mutex permits buffer reuse through `OutputSink::send_frame(&self)`.
     pkt_buf: Mutex<BytesMut>,
 }
 
@@ -49,20 +45,18 @@ struct SpreadCfg {
 
 struct Metrics {
     frames: RateMeter,
-    /// Unique packets — one tick per distinct packet (excludes still-frame
-    /// redundancy duplicates). `pkt_jit` is read from this so still-frame
-    /// bursts don't show up as crushed-to-zero jitter.
+    /// Unique-packet timestamps exclude redundancy copies so packet jitter
+    /// measures spacing between distinct packets.
     unique_packets: RateMeter,
-    /// Physical UDP sends — one tick per `send_to`. Used for `phy` rate when
-    /// redundancy multiplies the on-wire packet count.
+    /// Physical send timestamps include redundancy copies for the on-wire rate.
     physical_packets: RateMeter,
     log_interval: Duration,
     last_log: Instant,
     /// Lifetime physical sends since stream start.
     tx_total: u64,
-    /// Last frame's `delay_ms` — for native-mode target FPS.
+    /// Last frame's `delay_ms`; for native-mode target FPS.
     last_delay_ms: f32,
-    /// Did the most recent frame actually engage spreading?
+    /// Whether the most recent frame used packet spreading.
     spread_active: bool,
 }
 
@@ -131,9 +125,8 @@ impl DdpSender {
         Ok(())
     }
 
-    /// Take ownership of the reusable per-packet buffer for the duration of
-    /// one frame emit. The caller hands it back via `return_pkt_buf` so the
-    /// allocation is reused on the next frame.
+    /// Takes temporary ownership of the packet allocation; use `return_pkt_buf`
+    /// after sending the frame.
     fn take_pkt_buf(&self) -> BytesMut {
         std::mem::replace(
             &mut *self.pkt_buf.lock(),
@@ -145,9 +138,8 @@ impl DdpSender {
         *self.pkt_buf.lock() = buf;
     }
 
-    /// Compute the spreading plan for a frame whose pacing wants
-    /// `delay_ms` between emits. Returns `None` when spreading is
-    /// disabled or the frame rate exceeds `spread_max_fps`.
+    /// Returns a packet-spreading plan, or `None` when disabled or above
+    /// the configured frame-rate limit. `delay_ms` is the frame interval.
     fn plan_spread(&self, delay_ms: f32, payload_bytes: usize) -> Option<spreading::Plan> {
         if !self.spread.enabled {
             return None;
@@ -193,7 +185,6 @@ impl DdpSender {
             let spread = m.spread_active;
             let last_delay_ms = m.last_delay_ms;
 
-            // pps formatting: surface redundancy multiplier when active.
             let pps_str = if (physical_pps - unique_pps).abs() > 0.5 {
                 let factor = if unique_pps > 0.0 {
                     physical_pps / unique_pps
@@ -205,7 +196,6 @@ impl DdpSender {
                 format!("{unique_pps:.0}")
             };
 
-            // Mode tag: pace=NHz vs native (~tgt fps from delay_ms).
             let mode_str = if self.pace_hz > 0 {
                 format!("pace={}Hz", self.pace_hz)
             } else {
@@ -257,9 +247,8 @@ impl OutputSink for DdpSender {
             }
             unique_packets = unique_packets.saturating_add(1);
 
-            // Apply spreading between unique-packet groups, not between
-            // redundant copies — matches the Python spec for still-frame
-            // redundancy that must be transmitted back-to-back.
+            // Redundant copies must be sent back-to-back; spread only between
+            // groups of distinct packets.
             if let Some(plan) = &spread_plan
                 && let Some(spacing) = plan.spacing
             {
@@ -294,7 +283,7 @@ impl OutputSink for DdpSender {
     }
 }
 
-/// Number of DDP packets a payload of `bytes` will split into.
+/// Returns the packet count for a payload of `bytes`.
 #[inline]
 pub fn packets_for(bytes: usize) -> usize {
     bytes.div_ceil(DDP_MAX_DATA)

--- a/src/output/ddp/spreading.rs
+++ b/src/output/ddp/spreading.rs
@@ -1,4 +1,4 @@
-//! Packet spreading — spread `pkt_count` DDP packets across one frame
+//! Packet spreading distributes DDP packets across one frame
 //! interval so the receiver's input buffer doesn't take the whole frame in
 //! one burst.
 
@@ -22,7 +22,7 @@ impl Plan {
     };
 }
 
-/// Compute `(spacing, group_n)` for spreading `pkt_count` packets across
+/// Computes `(spacing, group_n)` for spreading `pkt_count` packets across
 /// `frame_interval`. If neither is useful (zero packets / zero interval),
 /// returns `Plan::NONE`.
 pub fn compute_spacing_and_group(pkt_count: u32, frame_interval: Duration, cfg: &SpreadConfig) -> Plan {
@@ -84,7 +84,7 @@ mod tests {
 
     #[test]
     fn ideal_above_min_keeps_group_1() {
-        // 33ms / 10 = 3.3ms > 3ms min → group_n=1
+        // 33ms / 10 = 3.3ms > 3ms min -> group_n=1
         let cfg = SpreadConfig {
             min_spacing: Duration::from_millis(3),
             max_sleeps: 0,
@@ -95,7 +95,7 @@ mod tests {
 
     #[test]
     fn ideal_below_min_groups_up() {
-        // 33ms / 100 = 0.33ms < 3ms → group to reach min (10)
+        // 33ms / 100 = 0.33ms < 3ms -> group to reach min (10)
         let cfg = SpreadConfig {
             min_spacing: Duration::from_millis(3),
             max_sleeps: 0,

--- a/src/output/metrics.rs
+++ b/src/output/metrics.rs
@@ -1,14 +1,10 @@
-//! Rolling-window metrics: frame/packet rate, jitter, queue occupancy.
-//!
-//! One `RateMeter` per metric, logged every `log_interval`.
+//! Rolling event rates and inter-batch timing jitter.
 
 use std::collections::VecDeque;
 use std::time::{Duration, Instant};
 
-/// Each entry is `(timestamp, count)` so callers can record a batch of
-/// events that share an `Instant` (e.g. all DDP packets from one frame)
-/// without allocating an entry per event. Rate sums counts; jitter still
-/// reads inter-batch timestamps only.
+/// Stores one timestamp per event batch. Rates count events; jitter measures
+/// intervals between batches, avoiding an allocation for every event.
 pub struct RateMeter {
     window: Duration,
     ts: VecDeque<(Instant, u32)>,
@@ -26,8 +22,7 @@ impl RateMeter {
         self.tick_n(t, 1);
     }
 
-    /// Record `count` events that all happened at `t`. Stored as a single
-    /// entry — keeps the deque bounded by emit cadence, not by event count.
+    /// Records a batch at `t` and evicts expired entries. A zero count is ignored.
     pub fn tick_n(&mut self, t: Instant, count: u32) {
         if count == 0 {
             return;
@@ -64,7 +59,7 @@ impl RateMeter {
         if self.ts.len() < 3 {
             return 0.0;
         }
-        // Welford's online variance — single pass, no Vec alloc.
+        // Welford's online variance; single pass, no Vec alloc.
         let mut n: u64 = 0;
         let mut mean = 0.0f64;
         let mut m2 = 0.0f64;
@@ -105,7 +100,7 @@ mod tests {
         for i in 0..10 {
             m.tick(t0 + Duration::from_millis(i * 100));
         }
-        // 10 ticks over 900ms → ~10Hz
+        // 10 ticks over 900ms -> ~10Hz
         let r = m.rate_hz();
         assert!(r > 9.0 && r < 11.0, "rate was {r}");
     }
@@ -123,7 +118,7 @@ mod tests {
                 unitary.tick(t);
             }
         }
-        // Both meters see 1000 events across 900ms — rates must match.
+        // Both meters see 1000 events across 900ms; rates must match.
         assert!((batched.rate_hz() - unitary.rate_hz()).abs() < 1e-6);
     }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,8 +1,4 @@
-//! Output sinks. DDP is the only sink at present; new protocols slot in
-//! alongside it.
-//!
-//! Conflict addressing is a *sink* concern: each sink implementation owns
-//! its own collision rules via `reserve`.
+//! Frame sinks and metrics. DDP address reservations enforce stream exclusivity.
 
 pub mod ddp;
 pub mod metrics;

--- a/src/output/sink.rs
+++ b/src/output/sink.rs
@@ -1,4 +1,4 @@
-//! `OutputSink` trait + shared types.
+//! Frame sink interface and shared output types.
 
 use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -8,15 +8,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::OutputError;
 
-/// Opaque stream identity, assigned by the orchestrator. Separate from any
-/// protocol-level addressing (DDP tuples, URLs, etc.) so the orchestrator
-/// doesn't have to know what identifies a stream to the wire.
+/// Internal stream identity, independent of sink-specific destination addresses.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct StreamId(u64);
 
 impl StreamId {
     pub fn new() -> Self {
-        // Monotonic counter, safe against wrap-around for our cardinalities.
         static NEXT: AtomicU64 = AtomicU64::new(1);
         Self(NEXT.fetch_add(1, Ordering::Relaxed))
     }
@@ -45,8 +42,7 @@ pub enum PixelFormat {
 impl PixelFormat {
     pub fn from_str_canon(s: &str) -> Option<Self> {
         match s.to_ascii_lowercase().as_str() {
-            // Python sent RGB888 for the ddp-esphome rgbw option; the
-            // receiver converts RGB input for its RGBW light renderer.
+            // ddp-esphome converts RGB input for its RGBW renderer.
             "rgb888" | "rgbw" => Some(Self::Rgb888),
             "rgb565le" => Some(Self::Rgb565Le),
             "rgb565be" => Some(Self::Rgb565Be),
@@ -72,13 +68,11 @@ pub struct Frame {
     pub meta: FrameMeta,
 }
 
-/// An `OutputSink` represents a single stream in flight: the reservation
-/// (conflict + address binding) is already held, and `send_frame` pushes
-/// rendered frames out to the wire.
+/// Frame destination for a stream whose address reservation is already held.
 #[async_trait::async_trait]
 pub trait OutputSink: Send + Sync {
     async fn send_frame(&self, frame: Frame) -> Result<(), OutputError>;
 
-    /// Request an orderly shutdown (drain any buffered frames then close).
+    /// Requests sink cleanup. Transport ownership controls socket lifetime.
     async fn close(&self) -> Result<(), OutputError>;
 }

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,4 +1,4 @@
-//! OS-specific hooks. Currently just Windows timer resolution.
+//! Windows timer resolution and platform-specific hardware backend selection.
 
 #[cfg(windows)]
 pub struct WindowsTimerResolution {
@@ -7,8 +7,7 @@ pub struct WindowsTimerResolution {
 
 #[cfg(windows)]
 impl WindowsTimerResolution {
-    /// Calls `timeBeginPeriod(1)` on construction, `timeEndPeriod(1)` on drop.
-    /// No-ops when `enable` is false.
+    /// Requests millisecond timer resolution until drop when enabled.
     pub fn new(enable: bool) -> Self {
         if enable {
             // SAFETY: `timeBeginPeriod` is a stable Win32 API; `1` is a valid period.
@@ -42,10 +41,8 @@ impl WindowsTimerResolution {
     }
 }
 
-/// Pick the best hardware-accel backend given a preference + `ffmpeg -hwaccels` output.
-///
-/// `prefer` is one of `"auto"`, `"none"`, or a specific backend name. When `"auto"`,
-/// walks a platform-specific candidate list. Returns `None` if nothing matches.
+/// Selects an available backend in platform order for Auto, or matches a
+/// named preference. None or an unavailable preference selects CPU decoding.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HwBackend {
     Cuda,
@@ -78,7 +75,7 @@ impl HwBackend {
     }
 }
 
-/// Platform-appropriate candidate order when `prefer == "auto"`.
+/// Returns backend preference order for Auto selection.
 pub fn auto_candidates() -> &'static [HwBackend] {
     #[cfg(target_os = "windows")]
     {
@@ -110,11 +107,10 @@ mod tests {
     fn pick_auto_returns_first_available() {
         let avail = [HwBackend::Qsv, HwBackend::Vaapi];
         let picked = pick_hw_backend("auto", &avail);
-        // On Linux, auto tries vaapi first.
         #[cfg(all(unix, not(target_os = "macos")))]
         assert_eq!(picked, Some(HwBackend::Vaapi));
         #[cfg(target_os = "windows")]
-        assert_eq!(picked, Some(HwBackend::Qsv)); // cuda/d3d11 missing → qsv
+        assert_eq!(picked, Some(HwBackend::Qsv)); // CUDA and D3D11 are unavailable.
         #[cfg(target_os = "macos")]
         assert_eq!(picked, None); // videotoolbox missing
     }

--- a/src/render/bbcode.rs
+++ b/src/render/bbcode.rs
@@ -1,10 +1,10 @@
-//! BBCode → pixel-font rendering.
+//! BBCode -> pixel-font rendering.
 //!
 //! Supported tags:
-//! - `[color=red]…[/color]` or `[red]…[/red]` — text color
-//! - `[font=8x16]…[/font]` — Spleen font size
-//! - `[left]` / `[center]` / `[right]` — block alignment for following lines
-//! - `[b]…[/b]` — bold (simulated via double-draw)
+//! - `[color=red]...[/color]` or `[red]...[/red]`; text color
+//! - `[font=8x16]...[/font]`; Spleen font size
+//! - `[left]` / `[center]` / `[right]`; block alignment for following lines
+//! - `[b]...[/b]`; bold (simulated via double-draw)
 
 use crate::error::RenderError;
 use crate::render::blit::{Canvas, blit_string};
@@ -34,7 +34,7 @@ pub struct RenderOutput {
     pub height: u32,
 }
 
-/// Render `text` (possibly containing BBCode tags) into a `width`×`height`
+/// Renders `text` (possibly containing BBCode tags) into a `width`x`height`
 /// RGB888 buffer.
 pub fn render_bbcode_text(
     text: &str,
@@ -68,7 +68,7 @@ pub fn render_bbcode_text(
             };
             blit_string(&mut canvas, font, line, x, cursor_y, run.color);
             if run.bold {
-                // Double-draw one pixel to the right for a fake bold.
+                // Simulate bold with a second draw shifted one pixel right.
                 blit_string(&mut canvas, font, line, x + 1, cursor_y, run.color);
             }
             cursor_y += line_h;
@@ -82,9 +82,8 @@ pub fn render_bbcode_text(
     })
 }
 
-// The Python renderer groups style segments until a newline or alignment
-// change, then uses the first segment's style for that line. Preserve this
-// layout: an inline color/font tag must not move the remaining text down.
+// Newlines and alignment changes delimit rows. The first segment supplies
+// the row style; inline color/font changes do not start a row.
 fn logical_lines(runs: Vec<Run>) -> Vec<Run> {
     let mut lines = Vec::new();
     let mut current: Option<Run> = None;
@@ -116,8 +115,7 @@ fn build_background(width: u32, height: u32, bg: [u8; 3]) -> Vec<u8> {
     if bg == [0, 0, 0] {
         return vec![0u8; total];
     }
-    // Build one row, then double-up via `extend_from_within` so we copy O(log
-    // height) times instead of O(height) per-pixel `extend_from_slice` calls.
+    // Doubling the initialized rows copies the solid background in logarithmic steps.
     let row_len = (width as usize) * 3;
     let mut canvas = Vec::with_capacity(total);
     for _ in 0..width {
@@ -138,12 +136,9 @@ fn build_background(width: u32, height: u32, bg: [u8; 3]) -> Vec<u8> {
 }
 
 fn parse(text: &str, default_fg: [u8; 3]) -> Vec<Run> {
-    // Stateful parser over `[tag=value]...[/tag]`. Unknown tags fall through
-    // as literal text. All state lives in `Parser` so helpers can mutate it.
+    // Unknown tags remain literal text.
     let mut p = Parser {
         color_stack: vec![default_fg],
-        // Default to 5x8 — matches the Python baseline and the LED sizes
-        // callers typically target. `[font=8x16]` opts up explicitly.
         font_stack: vec![FontSize::S5x8],
         bold_stack: vec![false],
         align_stack: vec![Alignment::Left],
@@ -199,9 +194,7 @@ impl Parser {
         *self.align_stack.last().unwrap_or(&Alignment::Left)
     }
 
-    /// Drain the pending text into the runs vector, merging with the
-    /// previous run when all style/align attributes match so the renderer
-    /// doesn't re-enter the wrap path unnecessarily.
+    /// Merges adjacent runs with identical style to avoid separate wrap operations.
     fn flush(&mut self) {
         if self.buf.is_empty() {
             return;
@@ -231,8 +224,7 @@ impl Parser {
         });
     }
 
-    /// Handle one `[tag]` or `[tag=value]` (or `[/tag]`). Returns `true`
-    /// on recognition.
+    /// Returns whether the tag is recognized and updates parser state.
     fn try_tag(&mut self, body: &str) -> bool {
         let (name, value) = match body.split_once('=') {
             Some((n, v)) => (n, Some(v)),
@@ -305,7 +297,7 @@ impl Parser {
     }
 }
 
-/// Pop but never empty — BBCode stacks keep their root default entry.
+/// Pops only non-root entries so BBCode stacks retain their defaults.
 fn pop_if<T>(stack: &mut Vec<T>) {
     if stack.len() > 1 {
         stack.pop();
@@ -324,7 +316,6 @@ mod tests {
         assert_eq!(out.width, 64);
         assert_eq!(out.height, 16);
         assert_eq!(out.rgb888.len(), (64 * 16 * 3) as usize);
-        // Has at least one white pixel from the glyph blitter.
         assert!(
             out.rgb888
                 .as_chunks::<3>()
@@ -337,7 +328,6 @@ mod tests {
     #[test]
     fn bbcode_color_tag_recognized() {
         let out = render_bbcode_text("[red]x[/red]", 16, 16, [255, 255, 255], [0, 0, 0]).unwrap();
-        // Some red pixels should be present.
         assert!(
             out.rgb888
                 .as_chunks::<3>()
@@ -360,9 +350,8 @@ mod tests {
 
     #[test]
     fn unknown_tag_falls_through_literally() {
-        // `[img]` isn't a recognized tag — render as text.
+        // `[img]` isn't a recognized tag; render as text.
         let out = render_bbcode_text("[img]", 64, 16, [255, 255, 255], [0, 0, 0]).unwrap();
-        // Any white pixel means something was rendered (the literal `[img]`).
         assert!(
             out.rgb888
                 .as_chunks::<3>()

--- a/src/render/bdf.rs
+++ b/src/render/bdf.rs
@@ -1,10 +1,5 @@
-//! BDF (Bitmap Distribution Format) parser — minimal, just enough to render
-//! Spleen 5x8 / 6x12 / 8x16.
-//!
-//! Each glyph is stored as a bitmap indexed by `char`. The bitmap is packed
-//! left-to-right, top-to-bottom, one bit per pixel. `dwidth` is the advance
-//! width (pen movement after drawing). BBX describes the bounding box:
-//! `w h x_off y_off` where the offsets are relative to the origin.
+//! BDF font parsing with glyphs indexed by Unicode code point.
+//! Glyph rows are MSB-first and byte-aligned; BBX offsets are relative to the origin.
 
 use std::collections::HashMap;
 
@@ -22,10 +17,9 @@ pub struct Glyph {
     pub bbx_h: u16,
     /// X-offset of bounding box from origin.
     pub bbx_x: i16,
-    /// Y-offset of bounding box from origin (baseline = 0, ascenders > 0).
+    /// Bounding-box bottom relative to the baseline; positive values are above it.
     pub bbx_y: i16,
-    /// One byte per row, MSB-first within each byte, padded to byte boundary.
-    /// Length = `bbx_h * bytes_per_row`.
+    /// MSB-first rows padded to byte boundaries; length is `bbx_h * bytes_per_row`.
     pub bitmap: Vec<u8>,
     /// `ceil(bbx_w / 8)`, cached from parse so `pixel()` doesn't recompute.
     pub bytes_per_row: u16,
@@ -37,14 +31,14 @@ pub struct BdfFont {
     pub fbb_w: u16,
     /// Font-wide bounding box height.
     pub fbb_h: u16,
-    /// Ascent above baseline (top of font bbox above origin).
+    /// Font bounding-box bottom relative to the baseline, in pixels.
     pub fbb_y_off: i16,
     glyphs: HashMap<u32, Glyph>,
     default_advance: u16,
 }
 
 impl BdfFont {
-    /// Parse a BDF font from its textual representation.
+    /// Parses a BDF font from its textual representation.
     pub fn parse(text: &str) -> Result<Self, RenderError> {
         let mut lines = text.lines().map(str::trim);
         let mut fbb_w = 8u16;
@@ -85,7 +79,7 @@ impl BdfFont {
         self.glyph(c as u32).map_or(self.default_advance, |g| g.dwidth)
     }
 
-    /// Advance width of a whole string.
+    /// Returns the total pen advance in pixels, including fallback widths.
     pub fn measure(&self, text: &str) -> u32 {
         text.chars().map(|c| u32::from(self.advance_for(c))).sum()
     }
@@ -125,7 +119,6 @@ fn parse_glyph<'a>(lines: &mut impl Iterator<Item = &'a str>) -> Result<Option<G
     }
 
     let Some(code) = code else {
-        // Discard glyph until ENDCHAR without insertion.
         for l in lines.by_ref() {
             if l == "ENDCHAR" {
                 break;
@@ -190,7 +183,7 @@ mod tests {
 
     #[test]
     fn parses_minimal_bdf() {
-        // Tiny hand-written BDF: one glyph "A" (code 65), 4×5 box, advance 5.
+        // Hand-written BDF: one glyph "A" (code 65), 4x5 box, advance 5.
         let bdf = "\
 STARTFONT 2.1
 FONTBOUNDINGBOX 4 5 0 0
@@ -212,12 +205,12 @@ ENDFONT
         assert_eq!(g.dwidth, 5);
         assert_eq!(g.bbx_w, 4);
         assert_eq!(g.bbx_h, 5);
-        // Row 0: 0x40 = 0100 0000 → only bit col=1 set in the 4-wide bbox.
+        // Row 0: 0x40 = 0100 0000 -> only bit col=1 set in the 4-wide bbox.
         assert!(!g.pixel(0, 0));
         assert!(g.pixel(1, 0));
         assert!(!g.pixel(2, 0));
         assert!(!g.pixel(3, 0));
-        // Row 2: 0xF0 = 1111 0000 → all 4 bits set.
+        // Row 2: 0xF0 = 1111 0000 -> all 4 bits set.
         assert!(g.pixel(0, 2));
         assert!(g.pixel(3, 2));
     }
@@ -244,7 +237,7 @@ ENDCHAR
 ENDFONT
 ";
         let font = BdfFont::parse(bdf).unwrap();
-        assert_eq!(font.measure("AA"), 12); // 6 + 6
+        assert_eq!(font.measure("AA"), 12);
         assert_eq!(font.measure("AB"), 11); // 6 + default 5
     }
 }

--- a/src/render/blit.rs
+++ b/src/render/blit.rs
@@ -1,15 +1,15 @@
-//! Glyph blitter — stamps BDF glyph bitmaps onto an RGB888 canvas.
+//! BDF glyph rendering onto RGB888 canvases.
 
 use crate::render::bdf::{BdfFont, Glyph};
 
-/// Per-call canvas + style pinned to one place so we're not juggling 8 args.
+/// Mutable RGB888 pixels and dimensions shared by glyph draws.
 pub struct Canvas<'a> {
     pub pixels: &'a mut [u8],
     pub width: u32,
     pub height: u32,
 }
 
-/// Blit a single glyph at pen position `(pen_x, pen_y)`. The glyph's own BBX
+/// Blits a single glyph at pen position `(pen_x, pen_y)`. The glyph's own BBX
 /// offsets position its bitmap relative to the origin; baseline sits at
 /// `pen_y + font_ascent`.
 pub fn blit_glyph(
@@ -45,7 +45,7 @@ pub fn blit_glyph(
     }
 }
 
-/// Blit a string, returning the pen advance after the last glyph.
+/// Draws a string and returns the final pen x-coordinate.
 pub fn blit_string(
     canvas: &mut Canvas<'_>,
     font: &BdfFont,

--- a/src/render/color.rs
+++ b/src/render/color.rs
@@ -1,4 +1,4 @@
-//! Color parsing — named CSS colors + hex shorthand/full.
+//! Named CSS colors and short or full hexadecimal color parsing.
 
 pub fn parse(s: &str) -> Option<[u8; 3]> {
     let lower = s.to_ascii_lowercase();
@@ -24,9 +24,7 @@ pub fn parse(s: &str) -> Option<[u8; 3]> {
 }
 
 pub fn named(name: &str) -> Option<[u8; 3]> {
-    // CSS3 named colors — subset that covers BBCode shorthand tags
-    // (`[purple]`, `[teal]`, `[pink]`, …) and URL specs. Alphabetized by
-    // word except for shared aliases (aqua/cyan, fuchsia/magenta).
+    // Named colors support BBCode shorthand tags and placeholder URL colors.
     match name {
         "aliceblue" => Some([240, 248, 255]),
         "aqua" | "cyan" => Some([0, 255, 255]),
@@ -82,8 +80,7 @@ pub fn named(name: &str) -> Option<[u8; 3]> {
     }
 }
 
-/// Pick black or white to contrast with `bg` using the WCAG relative
-/// luminance formula.
+/// Selects black or white from weighted sRGB brightness.
 pub fn auto_contrast(bg: [u8; 3]) -> [u8; 3] {
     let r = f32::from(bg[0]) / 255.0;
     let g = f32::from(bg[1]) / 255.0;

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,7 +1,5 @@
-//! Text rendering — BBCode parser + BDF font blitter.
-//!
-//! No MDI icon-atlas support: TTF rendering would pull in another dependency,
-//! and the bundled Spleen fonts do not contain MDI private-use glyphs.
+//! BBCode text rendering with bundled Spleen BDF fonts.
+//! MDI private-use glyphs require fonts and rasterization outside this renderer.
 
 pub mod bbcode;
 pub mod bdf;

--- a/src/render/wrap.rs
+++ b/src/render/wrap.rs
@@ -1,4 +1,4 @@
-//! Word wrap — pixel-accurate, BDF-font aware.
+//! Pixel-width word wrapping using BDF glyph advances.
 
 use crate::render::bdf::BdfFont;
 
@@ -19,7 +19,7 @@ pub fn wrap(text: &str, font: &BdfFont, max_width: u32) -> Vec<String> {
             if font.measure(&candidate) <= max_width {
                 current = candidate;
             } else if current.is_empty() {
-                // Single oversized word: accept anyway.
+                // Keep oversized words intact rather than splitting glyph sequences.
                 lines.push(word.to_string());
             } else {
                 lines.push(std::mem::take(&mut current));
@@ -48,8 +48,7 @@ mod tests {
     #[test]
     fn wraps_on_word_boundary() {
         let font = get(FontSize::S5x8).unwrap();
-        // Spleen 5x8 advance width is 5px per glyph → "hello world" is
-        // 11*5 = 55 pixels. With max_width = 30, we should get two lines.
+        // Each Spleen 5x8 glyph advances five pixels; the space makes this 55 pixels.
         let out = wrap("hello world", font, 30);
         assert_eq!(out.len(), 2);
         assert_eq!(out[0], "hello");

--- a/src/resolver/fake.rs
+++ b/src/resolver/fake.rs
@@ -1,5 +1,4 @@
-//! Fake resolver for integration tests: canned responses for registered
-//! URLs, optional passthrough for the rest.
+//! Registered resolver responses for tests, with optional passthrough for unknown URLs.
 
 use std::collections::HashMap;
 
@@ -11,7 +10,7 @@ use crate::error::ResolverError;
 #[derive(Default)]
 pub struct FakeResolver {
     map: HashMap<String, ResolveResponse>,
-    /// When set, returned for any URL not in `map`.
+    /// Allows unregistered URLs to pass through unchanged.
     passthrough: bool,
 }
 

--- a/src/resolver/http.rs
+++ b/src/resolver/http.rs
@@ -1,7 +1,5 @@
-//! Real HTTP resolver — POSTs to an external resolver sidecar.
-//!
-//! Wrap with [`super::PassthroughLayer`] for direct-media short-circuiting;
-//! this impl assumes every URL it sees needs full extraction.
+//! Posts resolution requests to an external service. [`super::PassthroughLayer`]
+//! bypasses this service for recognized direct media.
 
 use std::time::Duration;
 

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -1,15 +1,6 @@
-//! Resolver layer — translates an arbitrary input URL into a directly
-//! streamable URL plus any HTTP headers the upstream CDN expects.
-//!
-//! Implementations:
-//! - [`SubprocessResolver`] — local `yt-dlp` subprocess (default when on PATH)
-//! - [`HttpResolver`] — POST to an external resolver sidecar
-//! - [`NoopResolver`] — fail-closed for anything not already direct
-//! - [`FakeResolver`] — for tests
-//!
-//! All concrete impls are wrapped by [`PassthroughLayer`], which short-circuits
-//! direct-media URLs (file://, *.mp4, …) without calling through to the inner
-//! resolver. So every impl below only sees URLs that genuinely need extracting.
+//! Resolves source URLs to playable media and HTTP headers. [`PassthroughLayer`]
+//! bypasses extraction for recognized media; subprocess and HTTP implementations
+//! handle the remaining URLs, while [`NoopResolver`] rejects them.
 
 pub mod fake;
 pub mod http;
@@ -43,7 +34,7 @@ pub struct ResolveResponse {
     /// Size in bytes, if known.
     #[serde(default)]
     pub filesize: Option<u64>,
-    /// Unix timestamp; caller should re-resolve after this.
+    /// URL expiry in Unix seconds; retained as metadata without scheduled refresh.
     #[serde(default)]
     pub expires_at: Option<i64>,
 }
@@ -60,11 +51,7 @@ impl ResolveResponse {
         }
     }
 
-    /// Should the ffmpeg `cache:` protocol wrap this URL? Enabled for
-    /// looping playback of small files (typical YouTube short clips), where
-    /// fetching the same bytes per loop is wasteful. When the operator
-    /// disables caching via config, the orchestrator's rebuild-on-loop path
-    /// handles repetition instead.
+    /// Returns whether looping playback can cache the known file size within `max_bytes`.
     pub fn should_cache(&self, r#loop: bool, enabled: bool, max_bytes: u64) -> bool {
         enabled && r#loop && self.filesize.is_some_and(|sz| sz <= max_bytes)
     }
@@ -72,9 +59,8 @@ impl ResolveResponse {
 
 #[async_trait]
 pub trait Resolver: Send + Sync {
-    /// Resolve `url`. Direct-media URLs are short-circuited by
-    /// [`passthrough::PassthroughLayer`] before reaching impls; impls only
-    /// need to handle URLs that genuinely require extraction.
+    /// Returns playable media and headers. [`PassthroughLayer`] handles direct
+    /// media before invoking an extraction implementation.
     async fn resolve(&self, req: ResolveRequest) -> Result<ResolveResponse, ResolverError>;
 }
 

--- a/src/resolver/noop.rs
+++ b/src/resolver/noop.rs
@@ -1,6 +1,5 @@
-//! Fail-closed resolver. Used when neither a local `yt-dlp` nor an HTTP
-//! resolver sidecar is configured. Direct-media URLs still work because
-//! [`super::PassthroughLayer`] short-circuits them before reaching here.
+//! Rejects extraction requests when no resolver is configured.
+//! [`super::PassthroughLayer`] handles direct media before this resolver.
 
 use async_trait::async_trait;
 

--- a/src/resolver/passthrough.rs
+++ b/src/resolver/passthrough.rs
@@ -1,5 +1,4 @@
-//! Decorator that short-circuits the inner resolver for URLs already
-//! pointing at direct media (file://, *.mp4, *.gif, …).
+//! Bypasses extraction for media identified by URL hints or HTTP headers.
 
 use async_trait::async_trait;
 
@@ -24,8 +23,7 @@ impl Resolver for PassthroughLayer {
         if classify(&req.url).is_direct_media() {
             return Ok(ResolveResponse::passthrough(req.url));
         }
-        // Extensionless camera endpoints and signed CDN URLs may already be
-        // direct media. Only HTML/unknown responses need an extractor.
+        // Header checks recognize extensionless cameras and signed media URLs.
         if matches!(classify(&req.url), crate::stream::url::UrlKind::HttpUnknown)
             && crate::stream::probe::probe_http(&req.url, &self.user_agent)
                 .await

--- a/src/resolver/subprocess.rs
+++ b/src/resolver/subprocess.rs
@@ -1,7 +1,4 @@
-//! Local `yt-dlp` subprocess resolver. Thin adapter between the `Resolver`
-//! trait and [`crate::yt_dlp::YtDlp`] — translates `ResolveRequest` →
-//! format-selector + URL, calls `YtDlp::resolve`, translates `Info` →
-//! `ResolveResponse`.
+//! Adapts resolver requests to yt-dlp format selection and metadata extraction.
 
 use std::time::Duration;
 
@@ -29,9 +26,7 @@ impl SubprocessResolver {
 #[async_trait]
 impl Resolver for SubprocessResolver {
     async fn resolve(&self, req: ResolveRequest) -> Result<ResolveResponse, ResolverError> {
-        // Resolve the codec preference list against the backend ffmpeg will
-        // *actually* pick — auto-mode picks the platform's first available, a
-        // specific name passes through if supported, anything else → cpu list.
+        // Codec preference must match the backend available for decoding.
         let hw = pick_hw_backend(req.hw_prefer.as_deref().unwrap_or("auto"), hwaccel::available());
         let format_expr = build_format(&FormatParams {
             height: req.target_h,

--- a/src/stream/fetcher.rs
+++ b/src/stream/fetcher.rs
@@ -1,6 +1,4 @@
-//! HTTP / file:// → bytes. Shared by static-image and animated paths.
-//!
-//! Enforces the 50 MB cap from [`MAX_SIZE_LIMIT`].
+//! Reads local and HTTP image data, enforcing [`MAX_SIZE_LIMIT`] for decoding.
 
 use std::path::Path;
 use std::time::Duration;
@@ -68,9 +66,7 @@ async fn fetch_http(src_url: &str, user_agent: &str) -> Result<Vec<u8>, ImageErr
         });
     }
 
-    // Stream the body chunk-by-chunk so a server that lies about (or omits)
-    // Content-Length can't push past our cap — the trailing byte check
-    // alone would already have buffered MAX_SIZE_LIMIT + overflow first.
+    // Enforce the byte limit while reading; Content-Length can be absent or wrong.
     let mut stream = resp.bytes_stream();
     let mut buf: Vec<u8> = Vec::with_capacity(MEMORY_THRESHOLD);
     while let Some(chunk) = stream.next().await {

--- a/src/stream/frame_source.rs
+++ b/src/stream/frame_source.rs
@@ -1,7 +1,4 @@
-//! Frame source enum — the hot-path dispatch point for every stream.
-//!
-//! Enum (not trait object) per `rust.md` §Architectural Decisions:
-//! pattern-match on one of `Video`, `StaticImage`, `Animated`.
+//! Frame iteration for video channels, static images, and cached animations.
 
 use bytes::Bytes;
 use tokio::sync::oneshot;
@@ -22,14 +19,9 @@ pub enum FrameSource {
 
 pub struct VideoSource {
     pub rx: tokio::sync::mpsc::Receiver<RgbFrame>,
-    /// Filled by the ffmpeg-wait task with `Ok(())` on clean exit or a
-    /// classified `MediaError` (e.g. "Server returned 403 Forbidden") on
-    /// failure. `take_error()` consumes this after `next()` returns `None`.
+    /// ffmpeg exit result, consumed by `take_error` after frame delivery ends.
     completion: Option<oneshot::Receiver<Result<(), MediaError>>>,
-    /// Drop-only guard: when the source drops, the inner sender drops, the
-    /// matching receiver in the ffmpeg wait task fires, and the child is
-    /// explicit-killed. Without this, a stalled ffmpeg input read can keep
-    /// the subprocess alive after we cancel the stream.
+    /// Stops the ffmpeg worker when this source drops, including stalled input reads.
     _kill_guard: crate::video::subprocess::KillGuard,
 }
 
@@ -82,10 +74,8 @@ impl FrameSource {
         }
     }
 
-    /// After `next()` returns `None`, ask the source whether it ended
-    /// cleanly or with an error. Static and animated sources never error;
-    /// for video, this awaits the ffmpeg exit-status oneshot and returns
-    /// the classified error if any.
+    /// Returns the video process error after `next` yields `None`.
+    /// Static and animated sources return no error; video waits for process completion.
     pub async fn take_error(&mut self) -> Option<StreamError> {
         match self {
             Self::Video(v) => {
@@ -100,9 +90,8 @@ impl FrameSource {
         }
     }
 
-    /// Reset iteration state so the next `next()` re-emits from the start.
-    /// Returns `false` for `Video` — ffmpeg owns its own loop via
-    /// `-stream_loop -1`, the orchestrator handles the rebuild path.
+    /// Rewinds static and animated sources. Returns `false` for video, whose
+    /// repetition requires ffmpeg seeking or rebuilding through the orchestrator.
     pub fn try_rewind(&mut self) -> bool {
         match self {
             Self::Video(_) => false,

--- a/src/stream/handle.rs
+++ b/src/stream/handle.rs
@@ -1,5 +1,4 @@
-//! `StreamHandle` — the orchestrator returns this when a stream is spawned;
-//! the session owns it and calls `cancel()` on stop / disconnect.
+//! Session-owned stream parameters and cancellation notifications.
 
 use std::sync::Arc;
 
@@ -28,18 +27,17 @@ impl StreamHandle {
         self.stream_id
     }
 
-    /// The resolved fields the stream was spawned with. `update` uses these
-    /// as the base for merging partial updates.
+    /// Returns the original resolved parameters used as the base for partial updates.
     pub fn fields(&self) -> &StreamFields {
         &self.fields
     }
 
-    /// Signal the stream task to stop. Idempotent.
+    /// Notifies current cancellation waiters.
     pub fn cancel(&self) {
         self.cancel.notify_waiters();
     }
 
-    /// Wait for cancellation. Stream task's async select arm.
+    /// Waits for the next cancellation notification.
     pub async fn cancelled(&self) {
         self.cancel.notified().await;
     }

--- a/src/stream/http.rs
+++ b/src/stream/http.rs
@@ -1,17 +1,10 @@
-//! Shared `reqwest::Client` for media fetches and probes.
-//!
-//! `reqwest::Client` is `Arc`-backed and owns the connection pool, DNS
-//! cache, and TLS config. Constructing one per call defeats keep-alive.
-//! Per-request settings (timeout, user-agent, method) are layered on the
-//! `RequestBuilder`, so a single shared client serves probe HEADs and
-//! fetcher GETs alike.
+//! Shared HTTP client for connection reuse across media fetches and probes.
 
 use std::sync::LazyLock;
 
 use reqwest::Client;
 
 pub static CLIENT: LazyLock<Client> = LazyLock::new(|| {
-    // No top-level timeout — callers set their own per request. Default
-    // redirect policy (limited(10)) covers our needs.
+    // Callers set deadlines; the client retains reqwest's default redirect limit.
     Client::builder().build().unwrap_or_else(|_| Client::new())
 });

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1,5 +1,4 @@
-//! Stream orchestration: per-stream state machine, FrameSource enum,
-//! producer/sampler (paced mode), native cadence runner.
+//! Source routing, playback runners, and per-stream lifecycle management.
 
 pub mod fetcher;
 pub mod frame_source;

--- a/src/stream/orchestrator.rs
+++ b/src/stream/orchestrator.rs
@@ -1,5 +1,4 @@
-//! Orchestrator: spawn per-stream tasks, own the DDP registry, hand back
-//! `StreamHandle`s for session-level cancellation.
+//! Owns stream tasks and DDP reservations; sessions control them through handles.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -19,14 +18,10 @@ use crate::resolver::Resolver;
 use crate::stream::handle::StreamHandle;
 use crate::stream::runner;
 
-/// Upper bound on retry attempts for transient errors (network failure,
-/// YouTube URL expiry, retryable decode faults).
+/// Retry budget for transient source and playback failures.
 const MAX_RETRIES: u32 = 3;
 
-/// Stop relooping after this many consecutive iterations produce zero frames.
-/// Catches the case where the source has gone permanently bad (e.g. a video
-/// URL now 403s — ffmpeg exits silently with no frames, the runner returns
-/// `Ok`, and the outer loop would otherwise spin forever).
+/// Bounds empty playback loops so a broken source cannot restart indefinitely.
 const MAX_EMPTY_LOOPS: u32 = 3;
 
 pub struct Orchestrator {
@@ -47,9 +42,8 @@ impl Orchestrator {
         }
     }
 
-    /// Spawn a stream task for `fields`. Returns a handle the caller uses
-    /// to cancel it. On cancellation or error, the task cleans itself up
-    /// via `Drop` semantics (reservation, sink, ffmpeg child).
+    /// Starts playback and returns a cancellation handle. Task exit releases
+    /// the DDP reservation, sink, and owned media processes.
     pub async fn spawn_stream(self: &Arc<Self>, fields: StreamFields) -> Result<StreamHandle, StreamError> {
         let stream_id = StreamId::new();
         let handle = StreamHandle::new(stream_id, fields.clone());
@@ -80,8 +74,7 @@ impl Orchestrator {
     }
 }
 
-/// Execute one stream lifecycle. The task exits on cancellation, when the
-/// source ends (non-looping), or on error.
+/// Runs until cancellation, failure, or non-looping source completion.
 async fn run_stream(
     fields: StreamFields,
     stream_id: StreamId,
@@ -91,7 +84,7 @@ async fn run_stream(
     frame_cache: FrameCache,
     resolver: Arc<dyn Resolver>,
 ) -> Result<(), StreamError> {
-    // Reserve DDP address — this displaces any previous stream on the same key.
+    // A destination/output pair can have only one active stream.
     let key = DdpKey {
         dest: fields.ddp_host,
         output_id: crate::control::fields::output_id_byte(fields.output_id),
@@ -101,7 +94,6 @@ async fn run_stream(
         .await
         .map_err(StreamError::Output)?;
 
-    // Build DDP sender.
     let sender: Arc<dyn OutputSink> = Arc::new(
         DdpSender::bind(
             fields.ddp_host,
@@ -126,9 +118,7 @@ async fn run_stream(
     Ok(())
 }
 
-/// Build the source and run it, retrying on transient errors with
-/// exponential backoff (0.5 → 1 → 2 s, ±50 ms jitter). Matches the
-/// YouTube-URL-expiry and network-blip recovery path.
+/// Runs playback with bounded exponential retries for transient failures.
 async fn run_with_retry(
     fields: &StreamFields,
     config: &Config,
@@ -136,9 +126,7 @@ async fn run_with_retry(
     resolver: &Arc<dyn Resolver>,
     sink: &dyn OutputSink,
 ) -> Result<(), StreamError> {
-    // Probe once per stream — Content-Type / magic bytes don't change for
-    // the lifetime of the source, so retries and loop iterations reuse the
-    // result instead of re-issuing HEAD requests.
+    // Reuse source classification across retries and playback loops.
     let kind = crate::stream::probe::probe(&fields.source, &config.net.user_agent).await;
     let mut attempt: u32 = 0;
     let mut empty_loops: u32 = 0;
@@ -164,12 +152,8 @@ async fn run_with_retry(
         match outcome {
             Ok(emitted) => {
                 if emitted == 0 {
-                    // Source built cleanly but produced no frames — most
-                    // commonly an ffmpeg subprocess that exited because the
-                    // upstream URL returned 4xx/5xx. Non-loop: surface as an
-                    // error instead of silently reporting "stream finished".
-                    // Loop: give up after a few consecutive empties so a
-                    // permanently-broken source doesn't spin forever.
+                    // Zero frames is a failure for one-shot playback. Looping sources get
+                    // a bounded number of empty attempts before failure.
                     empty_loops += 1;
                     if !fields.r#loop || empty_loops >= MAX_EMPTY_LOOPS {
                         return Err(StreamError::Media(MediaError::Network {
@@ -193,7 +177,7 @@ async fn run_with_retry(
                 }
                 empty_loops = 0;
 
-                // Non-cached video can only loop by rebuilding from scratch.
+                // Video sources that cannot rewind restart through source construction.
                 if fields.r#loop {
                     attempt = 0;
                     continue;
@@ -223,7 +207,6 @@ fn is_retryable(e: &StreamError) -> bool {
 }
 
 fn backoff(attempt: u32) -> Duration {
-    // 0.5s * 2^n, capped at 5s, plus 0..50ms jitter.
     let base_ms = 500u64.saturating_mul(1 << attempt).min(5000);
     let jitter_ms = rand::rng().random_range(0..50);
     Duration::from_millis(base_ms + jitter_ms)

--- a/src/stream/probe.rs
+++ b/src/stream/probe.rs
@@ -1,16 +1,5 @@
-//! Probe a normalized source URL for image-vs-video routing.
-//!
-//! `classify()` decides on URL scheme + extension alone. That's wrong for
-//! several real-world cases: `.jpg` URLs serving `multipart/x-mixed-replace`
-//! (IP-camera MJPEG) need the video pipeline, and extension-less HTTP URLs
-//! could be either. The Python version handled this with a pre-dispatch
-//! HEAD request; this module restores that behavior.
-//!
-//! Strategy:
-//! - `http(s)://` → HEAD request, branch on `Content-Type`.
-//! - `file://` → read the first ~512 bytes, sniff with `infer`.
-//! - `rtsp://` / `rtmp://` / `udp://` / `tcp://` → trust the scheme.
-//! - Anything ambiguous falls back to extension-based [`classify`].
+//! Routes sources by HTTP Content-Type, local magic bytes, or URL hints.
+//! Header probing handles extensionless media and MJPEG served from image URLs.
 
 use std::time::Duration;
 
@@ -29,9 +18,7 @@ pub enum MediaKind {
 const HEAD_TIMEOUT: Duration = Duration::from_secs(5);
 const FILE_SNIFF_BYTES: usize = 512;
 
-/// Probe `url` and return whether it should route to the image or video
-/// pipeline. Never errors — probe failures (network, missing file, parse)
-/// fall back to extension-based classification.
+/// Returns a media kind, falling back to URL hints when probing fails.
 pub async fn probe(url: &str, user_agent: &str) -> MediaKind {
     let Ok(parsed) = Url::parse(url) else {
         return fallback(url);
@@ -94,8 +81,7 @@ async fn probe_file(parsed: &Url) -> Option<MediaKind> {
 
 pub(crate) fn classify_content_type(ct: &str) -> Option<MediaKind> {
     let mime = ct.split(';').next().unwrap_or("").trim().to_ascii_lowercase();
-    // IP-camera MJPEG and similar pushed-frames streams: `.jpg`-extension
-    // URL but the response is a multipart stream that ffmpeg handles.
+    // MJPEG multipart responses require ffmpeg, even on image-like URLs.
     if mime == "multipart/x-mixed-replace" {
         return Some(MediaKind::Video);
     }
@@ -105,7 +91,6 @@ pub(crate) fn classify_content_type(ct: &str) -> Option<MediaKind> {
     if mime.starts_with("video/") || mime.starts_with("audio/") {
         return Some(MediaKind::Video);
     }
-    // Common video-ish containers/manifests served as `application/*`.
     if matches!(
         mime.as_str(),
         "application/vnd.apple.mpegurl"
@@ -116,15 +101,12 @@ pub(crate) fn classify_content_type(ct: &str) -> Option<MediaKind> {
     ) {
         return Some(MediaKind::Video);
     }
-    // Everything else (`text/html`, `application/octet-stream`, missing) →
-    // let the caller fall back to extension/scheme.
+    // Unrecognized MIME types leave routing to the URL fallback.
     None
 }
 
 fn fallback(url: &str) -> MediaKind {
-    // Extension wins when present — covers both `file://` URLs (which
-    // `classify` collapses to `LocalPath`) and HTTP URLs whose HEAD didn't
-    // produce a useful Content-Type.
+    // Check extensions before `classify`, which collapses local URLs to LocalPath.
     if let Some(k) = classify_extension(url) {
         return match k {
             UrlKind::DirectImage => MediaKind::Image,
@@ -132,9 +114,7 @@ fn fallback(url: &str) -> MediaKind {
         };
     }
     match classify(url) {
-        // No extension hint and bytes weren't recognizable. Local files
-        // without an extension go to the image pipeline (matches Python
-        // behavior); ambiguous HTTP URLs go to the resolver/ffmpeg path.
+        // Ambiguous local sources use the image decoder; HTTP sources use the resolver.
         UrlKind::LocalPath(_) => MediaKind::Image,
         _ => MediaKind::Video,
     }
@@ -257,8 +237,6 @@ mod tests {
 
     #[tokio::test]
     async fn probe_local_missing_file_falls_back() {
-        // No magic bytes available; falls through to extension-based
-        // classify, which sees `.png` → Image.
         let url = "file:///nonexistent/path/to/foo.png";
         assert_eq!(probe(url, "ua").await, MediaKind::Image);
     }

--- a/src/stream/runner.rs
+++ b/src/stream/runner.rs
@@ -1,8 +1,5 @@
-//! Per-stream runners: native cadence and paced mode.
-//!
-//! Native runs at the source's frame timing; paced samples the latest frame
-//! at a fixed `pace_hz` with optional EMA blending. Both reset their
-//! deadline when more than 100ms behind to prevent runaway catch-up bursts.
+//! Native playback follows source delays; paced playback samples the latest
+//! frame at a fixed rate with optional EMA blending. Late deadlines reset to limit bursts.
 
 use std::time::{Duration, Instant};
 
@@ -17,13 +14,10 @@ use crate::error::{MediaError, StreamError};
 use crate::output::sink::{Frame, FrameMeta, OutputSink};
 use crate::stream::frame_source::{FrameSource, RgbFrame};
 
-/// Upper bound on time between frames — if the source stalls this long we
-/// cut the stream and let the orchestrator decide whether to restart.
+/// Maximum wait for a source frame before retryable failure.
 const FRAME_WATCHDOG: Duration = Duration::from_secs(30);
 
-/// Watchdog trips surface as a retryable network condition rather than
-/// `Cancelled`, so the orchestrator's per-stream retry budget can rebuild
-/// the source instead of treating a stall as a permanent stop.
+/// Marks a stalled source as retryable so the orchestrator can rebuild it.
 fn watchdog_error(source_url: &str) -> StreamError {
     StreamError::Media(MediaError::Network {
         source_url: source_url.to_string(),
@@ -33,10 +27,8 @@ fn watchdog_error(source_url: &str) -> StreamError {
     })
 }
 
-/// Run at the source's native cadence. One frame pulled → one frame emitted,
-/// with timing based on the frame's `delay_ms` hint. Returns the number of
-/// frames emitted so the orchestrator can detect a source that died
-/// immediately (e.g. ffmpeg failing on a 403) versus one that ran normally.
+/// Emits frames at source cadence and returns the emitted count.
+/// Source, watchdog, and sink failures propagate to the orchestrator.
 pub async fn run_native(
     mut source: FrameSource,
     sink: &dyn OutputSink,
@@ -95,19 +87,9 @@ pub async fn run_native(
     }
 }
 
-/// Paced mode: producer pushes latest frame into a shared slot at source
-/// cadence; sampler emits `pace_hz` times per second, optionally EMA-blended
-/// against the previous emit.
-///
-/// The shared slot is a `parking_lot::Mutex<Option<Bytes>>` — the lock is
-/// only held for the duration of a clone or a swap, never across `.await`,
-/// so we don't need the heavier `tokio::Mutex`. The EMA path reuses one
-/// `BytesMut` across ticks instead of allocating a fresh out_buf + Bytes
-/// every emit.
-///
-/// Both sub-tasks return `Result<u64, StreamError>`: producer yields the
-/// frame count or the source-side error; sampler resolves only on a sink
-/// failure (otherwise loops forever, dropped when producer returns first).
+/// Samples source-paced frames at the requested rate, with optional EMA.
+/// Returns the produced frame count when the source ends, or a source/sink error.
+/// The shared frame lock is held only during swaps and clones, never across awaits.
 pub async fn run_paced(
     source: FrameSource,
     sink: &dyn OutputSink,
@@ -129,16 +111,12 @@ pub async fn run_paced(
                 Ok(Some(f)) => {
                     count += 1;
                     *latest.lock() = Some(f.rgb888);
-                    // A short, finite source can end before the sampler's
-                    // first tick. Do not report successful playback until
-                    // the first frame has actually reached the sink.
+                    // A finite source must reach the sink before completing, even at a slow pace.
                     if count == 1 {
                         first_emitted.notified().await;
                         deadline = time::Instant::now();
                     }
-                    // Decoders can produce much faster than playback. Keep
-                    // the producer on source cadence so sampling tracks
-                    // playback time.
+                    // Throttle decoding to source cadence so sampling follows playback time.
                     deadline += Duration::from_secs_f32(f.delay_ms.max(10.0) / 1000.0);
                     let now = time::Instant::now();
                     if deadline + Duration::from_millis(100) < now {
@@ -215,13 +193,10 @@ pub async fn run_paced(
             if next > now {
                 time::sleep(next - now).await;
             } else {
-                // Missed tick — reset.
                 next = now;
             }
         }
-        // Unreachable: the loop above only exits via `?` propagating a sink error.
-        // The trailing expression gives the async block a concrete `Ok` arm so
-        // both `select!` branches share `Result<u64, StreamError>`.
+        // Supplies the async block's result type; sink failures exit through `?`.
         #[allow(unreachable_code)]
         Ok::<u64, StreamError>(0)
     };
@@ -232,16 +207,9 @@ pub async fn run_paced(
     }
 }
 
-/// Update an EMA accumulator from a u8 frame and write the rounded/clamped
-/// u8 result into `out`. SIMD path processes 8 lanes at a time via
-/// `wide::f32x8`; tail handled scalar. With `target-cpu=x86-64-v3` this maps
-/// to AVX2 + FMA.
-///
-/// Math: `buf[i] = buf[i] * (1-α) + src[i] * α`, then
-/// `out[i] = clamp(round(buf[i]), 0, 255) as u8`.
-///
-/// Both paths use `mul_add` to fuse the multiply-add into a single rounded
-/// op, so the SIMD and scalar lanes produce bit-identical buffers.
+/// Blends `src` into the EMA accumulator and rounds/clamps output to bytes.
+/// The update is `buf * (1 - alpha) + src * alpha`; SIMD and scalar paths
+/// both use `mul_add` to keep their rounding consistent.
 fn ema_blend_into(buf: &mut [f32], src: &[u8], alpha: f32, out: &mut [u8]) {
     debug_assert_eq!(buf.len(), src.len());
     debug_assert_eq!(buf.len(), out.len());
@@ -277,7 +245,6 @@ fn ema_blend_into(buf: &mut [f32], src: &[u8], alpha: f32, out: &mut [u8]) {
             f32::from(src[i + 6]),
             f32::from(src[i + 7]),
         ]);
-        // FMA: sv * alpha_v + bv * inv_v, computed as one fused op.
         let new_b = sv.mul_add(alpha_v, bv * inv_v);
         let new_b_arr = new_b.to_array();
         buf[i..i + 8].copy_from_slice(&new_b_arr);
@@ -442,8 +409,6 @@ mod tests {
         assert_eq!(sink.sent.load(Ordering::Relaxed), 1);
     }
 
-    /// Paced watchdog: source never produces a frame, watchdog must trip
-    /// with a retryable error (so the orchestrator's retry budget applies).
     #[tokio::test(start_paused = true)]
     async fn paced_watchdog_returns_retryable() {
         let (source, _tx, _comp) = test_video_source();
@@ -453,7 +418,6 @@ mod tests {
         let result = tokio::select! {
             r = run_paced(source, &sink, &fields) => r,
             () = async {
-                // Advance past the watchdog window.
                 tokio::time::advance(FRAME_WATCHDOG + Duration::from_secs(1)).await;
                 std::future::pending::<()>().await;
             } => unreachable!(),
@@ -466,8 +430,6 @@ mod tests {
         }
     }
 
-    /// Native watchdog: same shape — must surface a retryable error so the
-    /// orchestrator can rebuild the source instead of giving up.
     #[tokio::test(start_paused = true)]
     async fn native_watchdog_returns_retryable() {
         let (source, _tx, _comp) = test_video_source();
@@ -490,15 +452,12 @@ mod tests {
         }
     }
 
-    /// Paced sink failure must propagate, not be swallowed: the runner
-    /// returns the Output error so the orchestrator sees the broken sink.
     #[tokio::test(start_paused = true)]
     async fn paced_sink_error_propagates() {
         let (source, tx, _comp) = test_video_source();
         let sink = CountingSink::new(1); // fail on first send
         let fields = test_fields();
 
-        // Push one frame so the sampler has something to send.
         tx.send(rgb_frame(fields.width as usize * fields.height as usize * 3))
             .await
             .unwrap();
@@ -506,7 +465,6 @@ mod tests {
         let result = tokio::select! {
             r = run_paced(source, &sink, &fields) => r,
             () = async {
-                // Let the sampler tick at least once; pace=30 → 33ms tick.
                 tokio::time::advance(Duration::from_millis(100)).await;
                 std::future::pending::<()>().await;
             } => unreachable!(),

--- a/src/stream/state.rs
+++ b/src/stream/state.rs
@@ -1,6 +1,4 @@
-//! Typed state machine for a single stream.
-//!
-//! Invalid transitions are type errors rather than runtime checks.
+//! Stream lifecycle states and runtime transition validation.
 
 use crate::error::StreamError;
 

--- a/src/stream/url.rs
+++ b/src/stream/url.rs
@@ -1,8 +1,5 @@
-//! URL classification — shared by the stream orchestrator, resolver, and fetcher.
-//!
-//! Sources from the wire are normalized to URL strings at the entry-point
-//! boundaries via [`normalize_source`]; everything downstream assumes URL
-//! form (`http://`, `https://`, `file://`, `rtsp://`, …).
+//! Normalizes source strings at control boundaries and classifies URL hints
+//! for routing, fetching, and resolver bypass.
 
 use std::path::PathBuf;
 
@@ -13,13 +10,10 @@ const VIDEO_EXT: &[&str] = &[
     ".mp4", ".mkv", ".webm", ".mov", ".avi", ".flv", ".m4v", ".3gp", ".ts",
 ];
 
-/// Normalize a wire-level `src` into a URL string. Run at every entry-point
-/// boundary so downstream code can assume URL form.
-///
-/// Pipeline: trim → percent-decode → rewrite `internal:` → wrap bare paths
-/// in `file://`. Relative paths resolve against the server's cwd. Windows
-/// drive letters fall through to the path branch (`c:\foo` has `:` but
-/// not `://`).
+/// Returns a URL after trimming, percent-decoding, and rewriting internal sources.
+/// Bare paths become file URLs relative to the server working directory; Windows
+/// drive paths are recognized by the absence of `://`. Returns an error for empty
+/// input, an unavailable working directory, or an unrepresentable file URL.
 pub fn normalize_source(raw: &str, server_host: &str) -> Result<String, String> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
@@ -45,13 +39,12 @@ pub fn normalize_source(raw: &str, server_host: &str) -> Result<String, String> 
         .map_err(|()| format!("not a valid file path: {}", abs.display()))
 }
 
-/// Rewrite `internal:<path>[?query]` to `http://<server_host>/api/internal/<path>[?query]`.
-/// Returns the input unchanged if it's not an `internal:` URL.
+/// Rewrites `internal:<path>[?query]` under the server's `/api/internal/` route.
+/// Other source strings pass through unchanged.
 pub fn rewrite_internal(url: &str, server_host: &str) -> String {
     let Some(rest) = url.strip_prefix("internal:") else {
         return url.to_string();
     };
-    // `internal:ha/sensor.temp?foo=bar` → path = `ha/sensor.temp`, query = `foo=bar`
     let (path, query) = match rest.split_once('?') {
         Some((p, q)) => (p, Some(q)),
         None => (rest, None),
@@ -62,14 +55,12 @@ pub fn rewrite_internal(url: &str, server_host: &str) -> String {
     }
 }
 
-/// True for `http://` / `https://` URLs. Used by ffmpeg-arg builders that
-/// want to attach HTTP-protocol options (`-headers`, `-reconnect`).
+/// Returns whether ffmpeg HTTP options apply to this URL.
 pub fn is_http_url(url: &str) -> bool {
     url.starts_with("http://") || url.starts_with("https://")
 }
 
-/// Decode percent-escapes in a source URL. Falls back to the original
-/// string if the decoded bytes aren't valid UTF-8.
+/// Decodes percent escapes, preserving the input if decoding produces invalid UTF-8.
 pub fn percent_decode(s: &str) -> String {
     percent_encoding::percent_decode_str(s)
         .decode_utf8()
@@ -83,8 +74,7 @@ pub enum UrlKind {
     DirectImage,
     DirectVideo,
     StreamingProtocol(&'static str),
-    /// HTTP/HTTPS without a recognized media extension — could be a page
-    /// that needs the resolver, or a direct stream with no hint.
+    /// HTTP URL requiring header inspection or extraction to identify its media.
     HttpUnknown,
     Unknown,
 }
@@ -107,12 +97,8 @@ pub fn classify(url: &str) -> UrlKind {
     UrlKind::Unknown
 }
 
-/// Inspect the URL's extension (ignoring query/fragment) and return
-/// `DirectImage` / `DirectVideo` if recognized. Used by [`probe`] to
-/// classify `file://` URLs by extension when magic-byte detection fails,
-/// and as a fallback when HEAD doesn't return a useful Content-Type.
+/// Classifies recognized image or video extensions, ignoring query and fragment.
 pub fn classify_extension(url: &str) -> Option<UrlKind> {
-    // Strip query and fragment so `foo.png?token=…` still matches `.png`.
     let path_part = url.split_once('?').map_or(url, |(p, _)| p);
     let path_part = path_part.split_once('#').map_or(path_part, |(p, _)| p);
     let lower = path_part.to_ascii_lowercase();
@@ -125,19 +111,13 @@ pub fn classify_extension(url: &str) -> Option<UrlKind> {
     None
 }
 
-/// Returns a local filesystem path for `file://…` URLs. After
-/// [`normalize_source`] runs at every entry-point boundary, scheme-less
-/// paths shouldn't reach this function; only `file://` URLs need to be
-/// recognized. `Url::to_file_path` handles cross-platform decoding (drive
-/// letters on Windows, UNC shares, percent-decoding).
+/// Converts file URLs to paths, including platform-specific drive and UNC syntax.
 pub fn as_local_path(url: &str) -> Option<PathBuf> {
     Url::parse(url).ok().and_then(|u| u.to_file_path().ok())
 }
 
 impl UrlKind {
-    /// True if the orchestrator should dispatch this URL through the video
-    /// pipeline (resolver + ffmpeg). `HttpUnknown` is included so yt-dlp
-    /// pages reach the resolver and bare HTTP streams reach ffmpeg.
+    /// Returns whether URL hints suggest video, including HTTP sources needing extraction.
     pub fn is_video(&self) -> bool {
         matches!(
             self,
@@ -145,8 +125,7 @@ impl UrlKind {
         )
     }
 
-    /// True if the resolver can short-circuit — the URL already points at
-    /// direct media and doesn't need yt-dlp.
+    /// Returns whether URL hints identify media that can bypass extraction.
     pub fn is_direct_media(&self) -> bool {
         matches!(
             self,
@@ -166,8 +145,6 @@ mod tests {
 
     #[test]
     fn file_url_is_local_path() {
-        // After normalization, local paths reach `classify` as `file://`
-        // URLs; bare paths are no longer valid input here.
         let k = classify("file:///tmp/foo.png");
         assert!(matches!(k, UrlKind::LocalPath(_)));
         assert!(k.is_direct_media());

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -29,10 +29,8 @@ impl LogLevel {
     }
 }
 
-/// Initialize `tracing` with a compact output format that's readable at a
-/// glance and cheap to grep: `LEVEL target: message field=value …`. Drops
-/// the default ISO-8601 timestamp (systemd / Docker / the tty already stamp
-/// lines) and the ANSI colors (use `RUST_LOG_STYLE=always` to force them).
+/// Initializes compact tracing without timestamps. `RUST_LOG` overrides the
+/// configured level; `RUST_LOG_STYLE=always` enables ANSI colors.
 pub fn init(level: LogLevel) {
     let filter = EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| EnvFilter::new(format!("media_proxy={}", level.as_filter())));

--- a/src/video/autocrop.rs
+++ b/src/video/autocrop.rs
@@ -1,17 +1,5 @@
-//! Black-bar autocrop.
-//!
-//! Algorithm:
-//! - Probe N frames.
-//! - For each, walk inward from each edge; stop once a row/column's median
-//!   luma exceeds `luma_thresh`.
-//! - Cap walk distance at `max_bar_ratio * dim`.
-//! - Record per-frame results; take per-edge median at end of probe.
-//!
-//! The probe is run in a tiny scaled-down grayscale space (`PROBE_W` x
-//! `PROBE_H`) for speed; the resulting bar widths are scaled back into
-//! source pixel coordinates before being handed to the filter graph's
-//! `crop=` filter. This preserves Python's logical behaviour while
-//! avoiding a full-resolution decode pass.
+//! Detects black bars from grayscale frame samples. Edge medians are capped by
+//! `max_bar_ratio`, then mapped from probe dimensions to source pixels.
 
 use std::process::Stdio;
 use std::time::Duration;
@@ -26,21 +14,17 @@ use crate::stream::url::is_http_url;
 use crate::video::filter_graph::AutocropRect;
 use crate::video::subprocess::add_http_reconnect_args;
 
-/// Tiny working resolution for the probe. Big enough to give edge walks
-/// useful resolution while keeping the decode cheap on live sources.
+/// Probe dimensions balance edge precision against decoding cost.
 const PROBE_W: u32 = 160;
 const PROBE_H: u32 = 120;
 
-/// Hard ceiling on probe wall time. Live sources (RTSP/MJPEG) can stall
-/// indefinitely if the network blips during the brief decode window;
-/// we'd rather skip autocrop than block stream startup.
+/// Limits probe time so stalled live sources cannot block stream startup.
 const PROBE_TIMEOUT: Duration = Duration::from_secs(8);
 
-/// Reused for ffmpeg's `-rw_timeout` so HTTP reads can't outlive the
-/// outer probe budget.
+/// HTTP read timeout, shorter than the outer probe budget.
 const HTTP_RW_TIMEOUT: Duration = Duration::from_secs(6);
 
-/// Compute the median-of-medians for each edge over a set of per-frame samples.
+/// Returns per-edge medians across frame samples.
 pub fn median_rect(samples: &[AutocropRect]) -> Option<AutocropRect> {
     if samples.is_empty() {
         return None;
@@ -61,15 +45,9 @@ pub fn median_rect(samples: &[AutocropRect]) -> Option<AutocropRect> {
     })
 }
 
-/// Decode `cfg.probe_frames` frames at a small grayscale resolution,
-/// detect black bars per frame, and return the median rect in **probe
-/// coordinates** (`PROBE_W × PROBE_H`). The caller maps it back to
-/// source coordinates with [`finalize_autocrop_rect`] once source dims
-/// are known — this split lets the autocrop probe run in parallel with
-/// the ffprobe metadata pre-pass that supplies those dims.
-///
-/// Returns `None` on timeout, ffmpeg failure, or a frame budget that
-/// produces no usable samples — the caller falls back to "no crop".
+/// Returns median bar widths in probe coordinates; `None` means probing failed
+/// or produced no frames. Use [`finalize_autocrop_rect`] once source dimensions
+/// are available, allowing this probe to run alongside metadata extraction.
 pub async fn probe_autocrop_rect(
     url: &str,
     headers: Option<&str>,
@@ -105,9 +83,7 @@ pub async fn probe_autocrop_rect(
     median_rect(&samples)
 }
 
-/// Map a probe-coordinate rect back to source pixels and apply
-/// `min_bar_px`. Pulled out so dispatch can delay the source-dim
-/// dependency to after both probes complete.
+/// Maps probe edges to source pixels and suppresses bars below `min_bar_px`.
 pub fn finalize_autocrop_rect(
     probe: AutocropRect,
     src_dims: (u32, u32),
@@ -162,9 +138,7 @@ async fn decode_grayscale_frames(
         let mut buf = vec![0u8; frame_bytes];
         match stdout.read_exact(&mut buf).await {
             Ok(_) => frames.push(buf),
-            // EOF before we hit the frame budget — short clip, partial
-            // probe is fine. Any caller that gets zero frames will skip
-            // autocrop in `probe_autocrop`.
+            // Short clips can provide fewer samples; zero samples disable autocrop.
             Err(_) => break,
         }
     }
@@ -172,10 +146,8 @@ async fn decode_grayscale_frames(
     Ok(frames)
 }
 
-/// Walk inward from each edge, stop at the first row/column whose median
-/// luma exceeds `luma_thresh`. The walk is capped at
-/// `max_bar_ratio * dim` so brightly lit content with a single dark band
-/// (e.g. a starry night sky) doesn't get mistaken for a letterbox.
+/// Finds each edge's first row or column above `luma_thresh`.
+/// `max_bar_ratio` limits cropping of dark content mistaken for letterboxing.
 fn detect_bars(frame: &[u8], w: u32, h: u32, cfg: &AutocropConfig) -> AutocropRect {
     let max_v = ((h as f32) * cfg.max_bar_ratio).floor() as u32;
     let max_h = ((w as f32) * cfg.max_bar_ratio).floor() as u32;
@@ -189,9 +161,7 @@ fn detect_bars(frame: &[u8], w: u32, h: u32, cfg: &AutocropConfig) -> AutocropRe
     }
 }
 
-/// Step from index 0 toward `max`, return the first index whose median
-/// luma exceeds `thresh`. Returns `max` if the whole walk stayed below
-/// threshold (i.e. a fully-black band hit the cap).
+/// Returns the first index above `thresh`, or `max` if the band stays dark.
 fn walk_edge(max: u32, thresh: u8, median_at: impl Fn(u32) -> u8) -> u32 {
     for i in 0..max {
         if median_at(i) > thresh {
@@ -216,9 +186,8 @@ fn col_median(frame: &[u8], w: u32, h: u32, col: u32) -> u8 {
     buf[buf.len() / 2]
 }
 
-/// Map a probe-resolution rect back to source coordinates and apply the
-/// `min_bar_px` floor: bars smaller than the floor are zeroed out so a
-/// few off-pixel edge samples don't crop content.
+/// Maps probe edges to source pixels, discarding bars below `min_bar_px`
+/// to avoid cropping isolated dark edge pixels.
 fn scale_to_source(probe: AutocropRect, src: (u32, u32), cfg: &AutocropConfig) -> AutocropRect {
     let (sw, sh) = src;
     let scale = |v: u32, probe_dim: u32, src_dim: u32| -> u32 {
@@ -291,8 +260,7 @@ mod tests {
 
     #[test]
     fn walk_capped_by_max_ratio() {
-        // Solid black frame — walk would scan the whole image, but
-        // max_bar_ratio caps it so the rect can't exceed half the dim.
+        // The ratio cap also applies to fully black frames.
         let w = PROBE_W as usize;
         let h = PROBE_H as usize;
         let f = vec![0u8; w * h];
@@ -305,10 +273,7 @@ mod tests {
 
     #[test]
     fn scale_to_source_applies_floor() {
-        // 1px bar at probe scale, scaled to a 160x120 source = 1px. 1 is
-        // below `min_bar_px=2`, so the floor zeroes it out. This protects
-        // against single-pixel edge artefacts being treated as a real
-        // letterbox.
+        // Isolated dark pixels fall below the minimum bar width.
         let probe_rect = AutocropRect {
             l: 1,
             r: 0,
@@ -321,7 +286,7 @@ mod tests {
 
     #[test]
     fn scale_to_source_maps_proportionally() {
-        // 24/120 of probe height → 24/120 * 1080 = 216px of source.
+        // 24/120 of probe height -> 24/120 * 1080 = 216px of source.
         let probe_rect = AutocropRect {
             l: 0,
             r: 0,

--- a/src/video/dispatch.rs
+++ b/src/video/dispatch.rs
@@ -1,30 +1,4 @@
-//! Video dispatch: resolver → ffprobe → autocrop probe → ffmpeg →
-//! `VideoSource` frame channel.
-//!
-//! Flow for a `StartStream` pointing at a video URL:
-//!
-//! 1. `Resolver::resolve` yields a direct stream URL + HTTP headers.
-//!    For local files and already-direct media, the passthrough resolver
-//!    returns the input unchanged.
-//! 2. **ffprobe pre-pass** (bounded, best-effort) extracts source
-//!    dimensions, SAR, and rotation. On failure (timeout, no metadata)
-//!    we fall back to the target-only graph — no probe data, no autocrop,
-//!    Auto-fit degrades to Pad.
-//! 3. **Autocrop probe** (bounded, best-effort) when
-//!    `config.video.autocrop.enabled`: decode N small grayscale frames,
-//!    take per-edge median, map back to source coords.
-//! 4. Pick a hwaccel backend from `config.hw.prefer` intersected with
-//!    ffmpeg's reported `-hwaccels`.
-//! 5. Build the `-vf` chain with probed dims/SAR + autocrop rect so
-//!    Auto-fit can choose direct-scale and the crop filter can trim
-//!    letterboxes. Rotation is left to ffmpeg's auto-rotate (since 4.2);
-//!    we swap the probed dims for 90°/270° rotations so Auto-fit's
-//!    ratio comparison runs on display orientation.
-//! 6. Spawn ffmpeg with `-f rawvideo -pix_fmt rgb24` on stdout + showinfo
-//!    on stderr.
-//! 7. A conversion task drains the ffmpeg frame receiver, computes each
-//!    frame's display delay from consecutive PTS, and forwards `RgbFrame`s
-//!    into the `VideoSource` channel the runner consumes.
+//! Resolves video URLs, probes metadata and autocrop, and starts ffmpeg frame delivery.
 
 use std::sync::Arc;
 
@@ -42,8 +16,7 @@ use crate::video::probe::{self, VideoProbeData};
 use crate::video::subprocess::{FfmpegArgs, FfmpegFrame, FfmpegInput, spawn_ffmpeg};
 use crate::video::{hwaccel, timing};
 
-/// Fallback delay when neither PTS deltas nor an advertised fps are
-/// available — ≈ 30 fps.
+/// Fallback frame delay in milliseconds when PTS and frame rate are unavailable.
 const DEFAULT_FRAME_DELAY_MS: f32 = 33.333;
 
 pub async fn build_video_source(
@@ -73,12 +46,7 @@ pub async fn build_video_source(
     }
     let http_headers = format_http_headers(&resolved.headers);
 
-    // Source-aware pre-passes run in parallel: ffprobe metadata is
-    // independent of the autocrop decode pass, and only the final
-    // probe-rect → source-coords mapping needs both. Any failure
-    // (timeout, missing binary, no video stream) falls back to today's
-    // target-only behaviour, so live or unusual sources don't block
-    // stream startup.
+    // The probes are independent; mapping crop edges to source pixels needs both results.
     let metadata_fut = probe::probe_video_metadata(&resolved.stream_url, http_headers.as_deref());
     let (probe_data, raw_autocrop_rect) = if config.video.autocrop.enabled {
         let crop_fut = autocrop::probe_autocrop_rect(
@@ -102,9 +70,8 @@ pub async fn build_video_source(
     let hw_backend = hwaccel::pick_for(fields.hw);
     let filter_graph = build_filter_graph_for(fields, probe_data.as_ref(), autocrop_rect);
 
-    // `cache:` makes the input seekable so ffmpeg's `-stream_loop -1` can
-    // rewind in-place. For large or non-looping media, the orchestrator
-    // rebuilds the whole source from scratch instead.
+    // `cache:` permits in-process seeking for small looping files. Other looping
+    // videos restart through the orchestrator when ffmpeg reaches EOF.
     let input = if resolved.should_cache(
         fields.r#loop,
         config.youtube.cache.enabled,
@@ -130,9 +97,7 @@ pub async fn build_video_source(
         .fps
         .and_then(|fps| if fps > 0.0 { Some(1000.0 / fps) } else { None });
 
-    // MJPEG / jpeg_pipe streams advertise synthetic PTS that doesn't reflect
-    // real frame arrival. Force fixed-interval pacing for these so burst
-    // arrivals don't produce burst emits downstream.
+    // Synthetic MJPEG timestamps do not reflect arrival time; use fixed delays.
     let unreliable_pts = is_unreliable_pts(&fields.source);
 
     let (frame_tx, frame_rx) = mpsc::channel::<RgbFrame>(8);
@@ -145,10 +110,7 @@ pub async fn build_video_source(
     )))
 }
 
-/// URL-level heuristic for formats that deliver synthetic PTS (MJPEG over
-/// HTTP is the common case on IP cameras). Keeping this at the URL layer
-/// avoids a mid-stream probe; any stream URL that smells like MJPEG is
-/// treated as "trust fps, not PTS".
+/// Identifies MJPEG URLs whose synthetic PTS requires fixed frame delays.
 fn is_unreliable_pts(src_url: &str) -> bool {
     let lower = src_url.to_ascii_lowercase();
     lower.ends_with(".mjpeg") || lower.ends_with(".mjpg") || lower.contains("mjpg_streamer")
@@ -173,16 +135,8 @@ fn contains_control(s: &str) -> bool {
     s.bytes().any(|b| b == b'\r' || b == b'\n' || b < 0x20)
 }
 
-/// Build the `-vf` chain. When `probe` is available the graph runs in
-/// source-aware mode: Auto-fit can pick direct-scale (matching ratios)
-/// or fall through to Pad, the autocrop crop is applied first when a
-/// rect is supplied, and Auto-fit's ratio comparison uses display
-/// (post-rotation) dimensions.
-///
-/// Rotation is left to ffmpeg's auto-rotate (since 4.2) — we don't emit
-/// `transpose` filters ourselves to avoid double-rotating against the
-/// auto-rotate already applied at decode time. For 90°/270° sources we
-/// swap probed `(w, h)` so Auto-fit compares ratios in display space.
+/// Builds filters using display dimensions for aspect-ratio comparisons.
+/// ffmpeg applies rotation during decode; rotating here would apply it twice.
 fn build_filter_graph_for(
     fields: &StreamFields,
     probe: Option<&VideoProbeData>,
@@ -205,9 +159,7 @@ fn build_filter_graph_for(
     })
 }
 
-/// Consume ffmpeg frames, convert each into an `RgbFrame` with a computed
-/// display delay, and forward. Terminates when the upstream closes (ffmpeg
-/// exited) or the downstream closes (runner dropped the receiver).
+/// Converts PTS to frame delays until either channel closes.
 async fn convert_frames(
     mut src: mpsc::Receiver<FfmpegFrame>,
     dst: mpsc::Sender<RgbFrame>,
@@ -280,17 +232,12 @@ mod tests {
 
     #[test]
     fn graph_without_probe_falls_back_to_pad() {
-        // Auto-fit with no probe data must conservatively emit a Pad
-        // chain — without source dims we can't compare ratios for a
-        // direct scale.
         let g = build_filter_graph_for(&fields(64, 64, Fit::Auto), None, None);
         assert!(g.contains("pad=64:64"));
     }
 
     #[test]
     fn graph_with_matching_ratio_picks_direct_scale() {
-        // 1080×1080 source vs 64×64 target: identical ratios, so the
-        // filter graph should skip the pad/crop chain and direct-scale.
         let p = probe(1080, 1080, 1, 1, 0);
         let g = build_filter_graph_for(&fields(64, 64, Fit::Auto), Some(&p), None);
         assert!(!g.contains("pad="), "graph should not pad on matching ratio: {g}");
@@ -299,9 +246,7 @@ mod tests {
 
     #[test]
     fn graph_with_portrait_rotated_source_uses_display_dims() {
-        // Container is 1080×1920 coded but rotated 90°: display is
-        // 1920×1080 landscape. Against a 1920×1080 target Auto-fit
-        // should pick direct-scale based on display ratio.
+        // Rotation makes the portrait-coded source match the landscape target.
         let p = probe(1080, 1920, 1, 1, 90);
         let g = build_filter_graph_for(&fields(1920, 1080, Fit::Auto), Some(&p), None);
         assert!(

--- a/src/video/filter_graph.rs
+++ b/src/video/filter_graph.rs
@@ -1,15 +1,5 @@
-//! Build the `-vf` filter graph string. Pure function, table-driven tests.
-//!
-//! Filter order matters: ffmpeg applies filters left-to-right and later
-//! filters depend on upstream normalization (square pixels, post-rotation
-//! orientation, range expansion baked into the downscale).
-//!
-//! Layout:
-//! ```text
-//! [crop_autocrop?] → scale iw*sar:ih → setsar=1 → transpose×N (rotation)
-//!     → scale target (+ expand range) → pad|crop (fit mode) → setdar=1
-//!     → format=rgb24
-//! ```
+//! Builds ffmpeg filters in dependency order: autocrop, square-pixel conversion,
+//! rotation, target scaling with range expansion, fitting, and RGB24 conversion.
 
 use std::fmt::Write;
 
@@ -23,9 +13,7 @@ pub struct AutocropRect {
 }
 
 pub struct FilterGraphParams {
-    /// Source dimensions (post-rotation), when known via a probe pass.
-    /// When `None`, Auto-fit conservatively falls through to Pad — the
-    /// smart direct-scale path needs source ratios to compare.
+    /// Source dimensions after rotation. `None` makes Auto fit use padding.
     pub src_dims: Option<(u32, u32)>,
     pub sar_num: u32,
     pub sar_den: u32,
@@ -33,30 +21,25 @@ pub struct FilterGraphParams {
     pub target_width: u32,
     pub target_height: u32,
     pub fit: Fit,
-    pub expand: u8, // 0=never, 1=auto, 2=force (tv→pc)
+    pub expand: u8, // 0=ffmpeg defaults, 1=auto input to full, 2=limited input to full
     pub autocrop: Option<AutocropRect>,
 }
 
-/// Build the `-vf` filter chain as a single string.
-///
-/// The output is wired into `ffmpeg -vf <this>` — comma-separated filter
-/// entries — not the lower-level `filter_complex` graph syntax.
+/// Returns a comma-separated filter chain for ffmpeg `-vf`.
 pub fn build_filter_graph(p: &FilterGraphParams) -> String {
     let mut s = String::new();
 
-    // Autocrop first, in source pixel coordinates. Without a source-dims
-    // probe we can't compute the crop rect — the dispatcher leaves
-    // `autocrop: None` in that case.
+    // Crop edges use source pixels, before SAR correction and target scaling.
     if let (Some(ac), Some((src_w, src_h))) = (&p.autocrop, p.src_dims) {
         let cw = src_w.saturating_sub(ac.l + ac.r).max(1);
         let ch = src_h.saturating_sub(ac.t + ac.b).max(1);
         let _ = write!(s, "crop={cw}:{ch}:{}:{},", ac.l, ac.t);
     }
 
-    // Unsqueeze PAR, then force SAR=1 so downstream scale works on square pixels.
+    // Normalize sample aspect ratio before target scaling.
     s.push_str("scale=iw*sar:ih,setsar=1,");
 
-    // Rotation via transpose. 180° is two `transpose=clock` chained.
+    // Two clockwise transposes produce a half-turn.
     match p.rotation_deg {
         90 => s.push_str("transpose=clock,"),
         180 => s.push_str("transpose=clock,transpose=clock,"),
@@ -64,7 +47,7 @@ pub fn build_filter_graph(p: &FilterGraphParams) -> String {
         _ => {}
     }
 
-    // Range-expand args live in the scale that performs the downscale to target.
+    // Apply range expansion during target scaling.
     let expand_args: &str = match p.expand {
         2 => ":in_range=tv:out_range=pc",
         1 => ":in_range=auto:out_range=pc",
@@ -85,8 +68,7 @@ pub fn build_filter_graph(p: &FilterGraphParams) -> String {
             );
         }
         Fit::Auto => {
-            // Scale direct if aspect ratios match; without source dims we
-            // can't compare ratios, so fall through to Pad conservatively.
+            // Unknown source dimensions prevent aspect-ratio comparison; use padding.
             let direct = p.src_dims.is_some_and(|(sw, sh)| {
                 let src_ratio = (sw as f64 * p.sar_num as f64) / (sh as f64 * p.sar_den.max(1) as f64);
                 let tgt_ratio = p.target_width as f64 / p.target_height.max(1) as f64;
@@ -156,7 +138,6 @@ mod tests {
 
     #[test]
     fn auto_with_matching_ratio_is_direct_scale() {
-        // 1:1 source → 64x64 target → ratios match → direct scale (no pad).
         let mut p = basic(Fit::Auto);
         p.src_dims = Some((1000, 1000));
         let s = build_filter_graph(&p);

--- a/src/video/hwaccel.rs
+++ b/src/video/hwaccel.rs
@@ -1,9 +1,5 @@
-//! Map `HwBackend` to ffmpeg CLI `-hwaccel` flag + surface detection.
-//!
-//! `ffmpeg -hwaccels` lists *compiled-in* support, not what works at runtime
-//! — distros ship binaries with `vaapi` enabled even on systems where
-//! `/dev/dri/renderD*` isn't accessible. We probe each listed backend by
-//! actually creating the hwdevice; only working ones are returned.
+//! Detects usable ffmpeg hardware backends by initializing each compiled-in
+//! device type. Listed backends can lack an accessible runtime device.
 
 use std::process::Command;
 use std::sync::OnceLock;
@@ -44,8 +40,7 @@ fn detect() -> Vec<HwBackend> {
     working
 }
 
-/// `-init_hw_device` calls `av_hwdevice_ctx_create` eagerly, so a failure
-/// here mirrors what the real decode would hit.
+/// Tests device creation; compiled-in support alone does not guarantee access.
 fn probe(backend: HwBackend) -> bool {
     let device_arg = format!("{}=probe", backend.as_ffmpeg_flag());
     Command::new("ffmpeg")
@@ -70,9 +65,7 @@ fn probe(backend: HwBackend) -> bool {
         .is_ok_and(|o| o.status.success())
 }
 
-/// Resolve a stream's hardware-accel preference against the system's
-/// available backends. `HwPref::None` opts out explicitly; `Auto` walks the
-/// platform candidate list; a specific backend is honored if available.
+/// Selects an available backend, using platform order for Auto and CPU for None.
 pub fn pick_for(pref: HwPref) -> Option<HwBackend> {
     platform::pick_hw_backend(pref.as_canon().unwrap_or("none"), available())
 }

--- a/src/video/mod.rs
+++ b/src/video/mod.rs
@@ -1,12 +1,4 @@
-//! Video pipeline — ffmpeg subprocess via `tokio::process`.
-//!
-//! Split into:
-//! - `filter_graph` — pure function, build the `-vf` chain (table-driven tests).
-//! - `subprocess`   — spawn ffmpeg, pipe RGB24 frames, parse `-vf showinfo` stderr for PTS.
-//! - `timing`       — consecutive-PTS → per-frame display delay.
-//! - `dispatch`     — resolver → ffmpeg spawn → `VideoSource` channel.
-//! - `autocrop`     — short probe for black-bar detection.
-//! - `hwaccel`      — map our `HwBackend` enum to ffmpeg CLI flags.
+//! Video decoding through ffmpeg. [`dispatch`] builds sources for the stream runners.
 
 pub mod autocrop;
 pub mod dispatch;

--- a/src/video/probe.rs
+++ b/src/video/probe.rs
@@ -1,11 +1,5 @@
-//! ffprobe pre-pass: extract source width/height/SAR/rotation/fps so the
-//! filter graph can do source-aware decisions (Auto-fit direct-scale,
-//! transpose for rotated content) before the main ffmpeg spawn.
-//!
-//! All failures are non-fatal — on probe error or timeout, callers fall
-//! back to the target-only graph (Pad fit, no rotation handling). This
-//! matters most for live sources (RTSP, MJPEG) where ffprobe can hang or
-//! return nothing useful: graceful degradation beats blocking forever.
+//! Extracts dimensions, sample aspect ratio, and rotation for video filters.
+//! Probe failures return no metadata so playback can proceed with target-only fitting.
 
 use std::process::Stdio;
 use std::time::Duration;
@@ -18,36 +12,27 @@ use tracing::{debug, warn};
 use crate::stream::url::is_http_url;
 
 const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
-/// Reused for ffprobe's `-rw_timeout` (microseconds) so a stalled socket
-/// doesn't outlive `PROBE_TIMEOUT`. Slightly tighter than `PROBE_TIMEOUT`
-/// to give ffprobe a chance to fail gracefully before tokio aborts it.
+/// HTTP read timeout, shorter than the outer probe deadline.
 const HTTP_RW_TIMEOUT: Duration = Duration::from_secs(4);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct VideoProbeData {
-    /// Coded source dimensions, before container rotation is applied.
-    /// For display-orientation dims (what a player would render), use
-    /// [`VideoProbeData::display_dims`].
+    /// Coded width before rotation; see [`Self::display_dims`] for display orientation.
     pub width: u32,
     pub height: u32,
     pub sar_num: u32,
     pub sar_den: u32,
-    /// Container rotation, normalised by [`normalise_rotation`] to one of
-    /// `{0, 90, 180, 270}`. `parse_ffprobe` is the only construction site
-    /// that produces `VideoProbeData`, so the invariant holds for all
-    /// values that reach external callers.
+    /// Clockwise rotation in degrees, rounded to a quarter-turn by the parser.
     pub rotation_deg: u32,
 }
 
 impl VideoProbeData {
-    /// Coded `(width, height)` — pre-rotation, as ffprobe reported.
+    /// Returns coded dimensions before rotation.
     pub fn dims(&self) -> (u32, u32) {
         (self.width, self.height)
     }
 
-    /// Display `(width, height)` — coded dims swapped for 90°/270°
-    /// container rotations, since ffmpeg auto-rotates at decode time and
-    /// the filter graph reasons in display orientation.
+    /// Returns dimensions after rotation, matching ffmpeg's decoded orientation.
     pub fn display_dims(&self) -> (u32, u32) {
         if matches!(self.rotation_deg, 90 | 270) {
             (self.height, self.width)
@@ -57,9 +42,7 @@ impl VideoProbeData {
     }
 }
 
-/// Run ffprobe with a hard timeout. Returns `None` on any failure
-/// (binary missing, timeout, JSON parse, no video stream). Callers must
-/// be prepared to continue without source-side metadata.
+/// Returns metadata, or `None` on timeout, process failure, or unusable output.
 pub async fn probe_video_metadata(url: &str, headers: Option<&str>) -> Option<VideoProbeData> {
     let raw = match time::timeout(PROBE_TIMEOUT, run_ffprobe(Command::new("ffprobe"), url, headers)).await {
         Ok(Ok(s)) => s,
@@ -157,8 +140,7 @@ fn parse_ffprobe(raw: &str) -> Option<VideoProbeData> {
     })
 }
 
-/// `"10:11"` → `(10, 11)`. `"0:1"` and unparseable values become `(1, 1)`,
-/// matching ffmpeg's "unknown SAR → assume square pixels" convention.
+/// Parses sample aspect ratio; missing, invalid, or zero values mean square pixels.
 fn parse_sar(s: Option<&str>) -> (u32, u32) {
     let Some(s) = s else { return (1, 1) };
     let Some((n, d)) = s.split_once(':') else {
@@ -169,9 +151,7 @@ fn parse_sar(s: Option<&str>) -> (u32, u32) {
     if n == 0 || d == 0 { (1, 1) } else { (n, d) }
 }
 
-/// Rotation source priority: side_data_list[].rotation (newer
-/// container metadata, signed degrees) wins over the legacy `rotate`
-/// stream tag (positive degrees as a string).
+/// Prefers display-matrix rotation over the string-valued `rotate` tag.
 fn extract_rotation(s: &FfprobeStream) -> f64 {
     if let Some(side) = s.side_data_list.iter().find_map(|sd| sd.rotation) {
         return side;
@@ -183,10 +163,7 @@ fn extract_rotation(s: &FfprobeStream) -> f64 {
         .unwrap_or(0.0)
 }
 
-/// Coerce arbitrary rotation values into one of {0, 90, 180, 270}.
-/// Negative values come from displaymatrix side data
-/// (e.g. -90 means 90° counter-clockwise = 270° clockwise). The filter
-/// graph emits transposes in clockwise terms, so we normalise here.
+/// Rounds rotation to a clockwise quarter-turn, accepting negative degrees.
 fn normalise_rotation(deg: f64) -> u32 {
     let n = ((deg.round() as i64).rem_euclid(360)) as u32;
     match n {
@@ -297,7 +274,7 @@ mod tests {
 
     #[test]
     fn rotation_from_side_data_negative() {
-        // Display matrix encodes -90 ≡ 270° clockwise.
+        // Display matrix encodes -90 = 270 degrees clockwise.
         let raw = r#"{"streams":[{"width":100,"height":100,"side_data_list":[{"rotation":-90.0}]}]}"#;
         let d = parse_ffprobe(raw).unwrap();
         assert_eq!(d.rotation_deg, 270);
@@ -352,9 +329,6 @@ mod tests {
             .unwrap_or(false)
     }
 
-    /// End-to-end: spawn ffprobe against a known synthetic source and
-    /// verify the parse + classification pipeline produces sensible
-    /// numbers. Pins the JSON shape against the actual ffprobe binary.
     #[tokio::test]
     #[allow(clippy::print_stderr)]
     async fn probe_lavfi_testsrc_returns_dims() {
@@ -362,12 +336,7 @@ mod tests {
             eprintln!("ffprobe not on PATH; skipping probe_lavfi_testsrc_returns_dims");
             return;
         }
-        // We can't pass `-f lavfi` through `probe_video_metadata` (it
-        // builds the args itself), so verify the full pipeline by
-        // running ffprobe directly against a tiny generated input. The
-        // shared parser is what we're really pinning here; the binary
-        // call is just to keep the JSON shape honest against the
-        // installed ffprobe version.
+        // The synthetic input needs lavfi options outside the production probe interface.
         let out = Command::new("ffprobe")
             .args([
                 "-hide_banner",

--- a/src/video/subprocess.rs
+++ b/src/video/subprocess.rs
@@ -1,14 +1,5 @@
-//! Spawn ffmpeg via `tokio::process`, pipe RGB24 frames, parse timing.
-//!
-//! Architectural choices:
-//! - **Subprocess, not in-process libav.** Rust bindings to FFmpeg are thin
-//!   and solo-maintained; the CLI has been API-stable for a decade.
-//! - **`-f rawvideo -pix_fmt rgb24`** on stdout — one byte frame of
-//!   `w * h * 3` per frame.
-//! - **`-vf showinfo`** in stderr for per-frame PTS. The parser matches on
-//!   `pts_time:<float>`. `showinfo` emits at `AV_LOG_INFO`, so we must run
-//!   ffmpeg at `-loglevel info` (or higher) — at `error` the lines are
-//!   suppressed and every frame falls back to a 33ms default delay.
+//! Streams RGB24 frames from ffmpeg stdout and reads PTS from stderr.
+//! The CLI isolates decoding from the Rust process and avoids libav binding dependencies.
 
 use std::process::Stdio;
 use std::sync::Arc;
@@ -33,40 +24,21 @@ enum ErrSeverity {
 
 type LastStderrErr = Arc<Mutex<Option<(ErrSeverity, String)>>>;
 
-/// Channels handed back to the dispatch layer when ffmpeg starts. The
-/// `completion` receiver yields the final result once ffmpeg exits — `Ok`
-/// for clean exit, `Err(MediaError)` carrying the classified stderr line
-/// (e.g. "Server returned 403 Forbidden") for failures.
-///
-/// Dropping the handles triggers an explicit ffmpeg kill via `_kill_tx`:
-/// the wait task selects on `child.wait()` vs the kill receiver, and
-/// dropping the sender resolves the receiver with `Err(RecvError)` on the
-/// same scheduler tick. Without this, a stalled HTTP read inside ffmpeg
-/// can keep the child alive long after the Rust side has cancelled —
-/// `kill_on_drop(true)` only fires when `Child` itself drops, but we move
-/// it into the wait task to call `wait()`. The kill channel re-establishes
-/// drop-driven termination.
+/// Owns frame and completion receivers plus the ffmpeg cancellation guard.
+/// Completion carries classified stderr errors for failed processes.
 pub(crate) struct FfmpegHandles {
     pub frames: mpsc::Receiver<FfmpegFrame>,
     pub completion: oneshot::Receiver<Result<(), MediaError>>,
-    /// Drop guard the wait task watches: when this sender drops, the wait
-    /// task explicit-kills the ffmpeg child. The dispatch layer must move
-    /// it into the `VideoSource` (or another long-lived owner) so it
-    /// outlives the FrameSource consumer.
+    /// Must live with the source; dropping it tells the wait task to kill ffmpeg.
     pub(crate) kill_guard: KillGuard,
 }
 
-/// Newtype wrapping the kill-channel sender. Carries no value — its only
-/// observable effect is when it drops, which resolves the matching
-/// receiver with `Err(RecvError)` and triggers the kill in the wait task.
-/// The inner sender is intentionally unread; the field exists only to be
-/// dropped.
+/// Signals cancellation on drop. The wait task owns `Child`, so child
+/// `kill_on_drop` alone cannot terminate a stalled source when its consumer exits.
 pub(crate) struct KillGuard(#[allow(dead_code)] oneshot::Sender<std::convert::Infallible>);
 
 impl KillGuard {
-    /// Construct a guard whose drop has no observable effect — the matching
-    /// receiver is dropped immediately. Used for tests that build a
-    /// `VideoSource` without a real ffmpeg subprocess behind it.
+    /// Returns a guard without a worker, for synthetic test sources.
     #[cfg(test)]
     pub(crate) fn detached() -> Self {
         let (tx, _rx) = oneshot::channel::<std::convert::Infallible>();
@@ -77,12 +49,8 @@ impl KillGuard {
 /// Detects hung connections so reconnect can fire instead of stalling.
 const HTTP_RW_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// Apply ffmpeg's HTTP reconnect/timeout flags to a `Command`. Used by
-/// the main spawn and the autocrop probe so a mid-stream TLS reset
-/// doesn't masquerade as a clean EOF (without reconnect, ffmpeg exits 0
-/// on the partial file). The two callers differ on `delay_max_secs` —
-/// the main pipeline gives reconnects more headroom, the probe wants to
-/// fail fast — but the rest of the chain is identical.
+/// Configures bounded HTTP reads and retries so transport failures do not
+/// become successful partial-file EOF. Autocrop uses a shorter retry delay.
 pub(crate) fn add_http_reconnect_args(cmd: &mut Command, rw_timeout: Duration, delay_max_secs: u32) {
     let timeout_us = rw_timeout.as_micros().to_string();
     let delay = delay_max_secs.to_string();
@@ -90,10 +58,8 @@ pub(crate) fn add_http_reconnect_args(cmd: &mut Command, rw_timeout: Duration, d
         .arg("1")
         .arg("-reconnect_streamed")
         .arg("1")
-        // Normal EOF must reach the decoder: reconnecting at every EOF
-        // stalls finite HTTP files and prevents their looping/seek path.
-        // Live inputs that close cleanly are rebuilt by the orchestrator
-        // when loop=true; read errors still use ffmpeg's reconnect flags.
+        // Reconnecting at normal EOF stalls finite files. Looping live inputs that
+        // close cleanly restart through the orchestrator; transport failures retry here.
         .arg("-reconnect_delay_max")
         .arg(&delay)
         .arg("-rw_timeout")
@@ -106,9 +72,7 @@ pub struct FfmpegFrame {
     pub pts_s: Option<f64>,
 }
 
-/// Input source for ffmpeg. `CachedLooping` ties together `cache:` (which
-/// makes the input seekable) and `-stream_loop -1` (which needs that
-/// seekability) so they can't be enabled independently and silently fail.
+/// Couples seekable `cache:` input with `-stream_loop -1` for cached playback.
 pub enum FfmpegInput<'a> {
     Direct(&'a str),
     CachedLooping(&'a str),
@@ -132,8 +96,7 @@ pub struct FfmpegArgs<'a> {
     pub http_headers: Option<String>,
 }
 
-/// Spawn ffmpeg and stream RGB24 frames over a channel. Caller drops the
-/// channel to stop.
+/// Starts RGB24 frame delivery. Drop the returned kill guard to stop ffmpeg.
 pub(crate) async fn spawn_ffmpeg(args: FfmpegArgs<'_>) -> Result<FfmpegHandles, VideoError> {
     let source_url = args.input.url().to_string();
     let frame_size = (args.output_width as usize) * (args.output_height as usize) * 3;
@@ -141,10 +104,7 @@ pub(crate) async fn spawn_ffmpeg(args: FfmpegArgs<'_>) -> Result<FfmpegHandles, 
     let mut cmd = Command::new("ffmpeg");
     cmd.arg("-hide_banner")
         .arg("-nostdin")
-        // `info` is required for `showinfo` (AV_LOG_INFO) to reach the
-        // stderr parser. The extra startup metadata at info level is
-        // harmless: the stderr classifier debug-routes anything it doesn't
-        // recognise as a known warning class.
+        // `showinfo` logs PTS at INFO; lower levels remove frame timing.
         .arg("-loglevel")
         .arg("info")
         .arg("-fflags")
@@ -170,7 +130,7 @@ pub(crate) async fn spawn_ffmpeg(args: FfmpegArgs<'_>) -> Result<FfmpegHandles, 
     };
     cmd.arg("-i").arg(&input_arg);
 
-    // Showinfo first so PTS logs come out before the output filters.
+    // Read timing after output filters so PTS corresponds to emitted frames.
     let vf = format!("{},showinfo", args.filter_graph);
     cmd.arg("-vf").arg(&vf);
 
@@ -200,12 +160,9 @@ pub(crate) async fn spawn_ffmpeg(args: FfmpegArgs<'_>) -> Result<FfmpegHandles, 
 
     let (tx, rx) = mpsc::channel::<FfmpegFrame>(8);
 
-    // Shared slot the stderr reader fills with the most relevant ffmpeg
-    // error line (first permanent wins; transient is overwritten freely).
-    // The wait task reads it on exit to construct a structured error.
+    // The wait task reads classified errors recorded by the stderr reader.
     let last_err: LastStderrErr = Arc::new(Mutex::new(None));
 
-    // Collect PTS values from stderr into a shared queue.
     let (pts_tx, pts_rx) = mpsc::channel::<f64>(64);
     tokio::spawn(stderr_reader(stderr, pts_tx, last_err.clone()));
 
@@ -214,10 +171,7 @@ pub(crate) async fn spawn_ffmpeg(args: FfmpegArgs<'_>) -> Result<FfmpegHandles, 
     let (completion_tx, completion_rx) = oneshot::channel();
     let (kill_tx, mut kill_rx) = oneshot::channel::<std::convert::Infallible>();
     tokio::spawn(async move {
-        // Two ways to leave: ffmpeg exits on its own, or the handles drop
-        // and `kill_rx` resolves (with Err since the sender is never used
-        // to send). On kill, we explicit-kill and reap; we skip emitting
-        // a completion result because the consumer has already gone away.
+        // Cancellation must kill and reap even when ffmpeg is blocked on input.
         let status = tokio::select! {
             s = child.wait() => Some(s),
             _ = &mut kill_rx => {
@@ -236,8 +190,7 @@ pub(crate) async fn spawn_ffmpeg(args: FfmpegArgs<'_>) -> Result<FfmpegHandles, 
                 let (message, retryable) = match last {
                     Some((ErrSeverity::Permanent, m)) => (m, false),
                     Some((ErrSeverity::Transient, m)) => (m, true),
-                    // No classified line — treat as transient and let the
-                    // orchestrator's retry budget cap it.
+                    // Unclassified failures use the orchestrator's bounded retry policy.
                     None => (format!("ffmpeg exited {s}"), true),
                 };
                 debug!(%s, retryable, %message, "ffmpeg exited with error");
@@ -299,7 +252,6 @@ async fn stderr_reader(stderr: ChildStderr, tx: mpsc::Sender<f64>, last_err: Las
             Ok(0) | Err(_) => return,
             Ok(_) => {}
         }
-        // Look for `pts_time:1.234` in the showinfo output.
         if let Some(idx) = line.find("pts_time:") {
             let rest = &line[idx + "pts_time:".len()..];
             let end = rest
@@ -314,9 +266,7 @@ async fn stderr_reader(stderr: ChildStderr, tx: mpsc::Sender<f64>, last_err: Las
         if trimmed.is_empty() {
             continue;
         }
-        // Classify common ffmpeg stderr lines so operators don't see every
-        // transient network blip as a `warn!`. The classification also feeds
-        // the wait-task's structured error: permanent → non-retryable.
+        // Error severity controls the orchestrator's retry decision.
         let lower = trimmed.to_ascii_lowercase();
         if lower.contains("http error 4")
             || lower.contains("server returned 4")
@@ -338,9 +288,7 @@ async fn stderr_reader(stderr: ChildStderr, tx: mpsc::Sender<f64>, last_err: Las
     }
 }
 
-/// First permanent line wins; later lines (permanent or transient) are
-/// dropped once a permanent is set. This ensures a 403 line isn't masked
-/// by a later "connection reset" the OS emits as the socket tears down.
+/// Keeps the first permanent error so a later connection teardown cannot mask it.
 fn record_stderr_err(slot: &LastStderrErr, sev: ErrSeverity, line: &str) {
     let mut g = slot.lock();
     if matches!(&*g, Some((ErrSeverity::Permanent, _))) {
@@ -365,12 +313,6 @@ mod tests {
             .unwrap_or(false)
     }
 
-    /// Pins the assumption that drives `spawn_ffmpeg`'s log-level choice:
-    /// `showinfo` emits at `AV_LOG_INFO`, so the loglevel must be at least
-    /// `info` for the per-frame `pts_time:` lines to reach our stderr
-    /// parser. The previous setting of `error` silently suppressed every
-    /// PTS line and demoted timing to a fixed 33ms default. Reads enough
-    /// stderr to see at least two distinct pts values, then aborts ffmpeg.
     #[tokio::test]
     #[allow(clippy::print_stderr)]
     async fn loglevel_info_emits_showinfo_pts_lines() {
@@ -378,8 +320,6 @@ mod tests {
             eprintln!("ffmpeg not on PATH; skipping loglevel_info_emits_showinfo_pts_lines");
             return;
         }
-        // 0.3s of 10fps synthetic input = 3 frames. Tiny size keeps the
-        // test fast (<200ms in practice).
         let mut child = Command::new("ffmpeg")
             .args([
                 "-hide_banner",

--- a/src/video/timing.rs
+++ b/src/video/timing.rs
@@ -1,11 +1,5 @@
-//! Per-frame display-delay calculator from consecutive PTS values.
-//!
-//! - First frame: if `avg_ms` is known (from declared fps) use it; else use
-//!   the caller's default.
-//! - Subsequent frames: `delta = (pts - prev_pts) * 1000`. With `avg_ms`
-//!   known, clamp `delta` to `[0.75 * avg, 1.25 * avg]` to absorb decoder
-//!   jitter. Without it, a non-positive delta gets the default.
-//! - Floor at `MIN_DELAY_MS` so downstream pacing never divides by 0.
+//! Converts consecutive PTS to frame delays, using a declared frame rate or
+//! fallback delay when timestamps are missing. Known frame rates bound jitter.
 
 pub const MIN_DELAY_MS: f32 = 10.0;
 
@@ -30,17 +24,14 @@ impl DelayClock {
         self.frames
     }
 
-    /// Compute the delay to hold the current frame before the next, never
-    /// below [`MIN_DELAY_MS`]. Always returns a valid delay — falls back
-    /// through `avg_ms` and then the `default_ms` the clock was built with.
+    /// Returns the current frame's delay in milliseconds, floored at [`MIN_DELAY_MS`].
+    /// Missing timestamps use the declared frame rate, then the configured fallback.
     pub fn next_delay(&mut self, pts_s: Option<f64>) -> f32 {
         self.frames += 1;
 
         let delta_ms = pts_s.zip(self.prev_pts_s).map(|(p, q)| ((p - q) * 1000.0) as f32);
 
-        // Always advance `prev_pts_s` when we have one, even when the delta
-        // is unusable (backwards PTS, reorders). Otherwise we'd compute the
-        // next delta against a stale anchor and drift indefinitely.
+        // Advance the anchor even on invalid deltas to avoid accumulating timing drift.
         if let Some(p) = pts_s {
             self.prev_pts_s = Some(p);
         }
@@ -79,7 +70,7 @@ mod tests {
     fn pts_jitter_clamped_to_avg_window() {
         let mut c = DelayClock::new(Some(33.33), 50.0);
         c.next_delay(Some(0.0));
-        // Burst: PTS moved 500 ms — must clamp to 1.25 × avg.
+        // Burst: PTS moved 500 ms ; must clamp to 1.25 * avg.
         let d = c.next_delay(Some(0.5));
         assert!(d <= 1.25 * 33.33);
     }
@@ -99,10 +90,6 @@ mod tests {
 
     #[test]
     fn backwards_pts_advances_anchor() {
-        // Consecutive PTS: 0.0, 0.0 (stall), 0.1. After the stall, the
-        // anchor must be the stalled value — not the pre-stall — so the
-        // 0.1 frame's delta is 100ms, not 200ms. This is the regression
-        // for the pre-fix bug where the early-return skipped the anchor update.
         let mut c = DelayClock::new(None, 33.0);
         c.next_delay(Some(0.0));
         c.next_delay(Some(0.0));

--- a/src/yt_dlp/_capture.py
+++ b/src/yt_dlp/_capture.py
@@ -1,9 +1,5 @@
-# Re-run via:  python3 src/yt_dlp/_capture.py
-#
-# Mirrors the pre-rewrite Python build_yt_dlp_format() exactly. Re-extracts
-# `try_60fps` as a parameter (Python read it from the global Config singleton)
-# and writes one fixture file per (height, hw, prefer_60fps, video_only) combo
-# so the Rust port can golden-test against them.
+# Generates format-selection fixtures from the Python reference implementation.
+# Run with: python3 src/yt_dlp/_capture.py
 
 import json
 import pathlib

--- a/src/yt_dlp/format.rs
+++ b/src/yt_dlp/format.rs
@@ -1,8 +1,5 @@
-//! yt-dlp `-f` format-selector builder. Pure string assembly from target
-//! height, hwaccel hint, and 60fps preference. Always prefers video-only
-//! progressive HTTPS streams; falls through to combined / any protocol only
-//! as last resort. Tiny displays are capped — pulling 1080p to render at
-//! 64×64 wastes bandwidth.
+//! Builds yt-dlp format preferences from target height and available hardware.
+//! The 720p/60fps preference precedes size-based tiers; final fallbacks have no height cap.
 
 use crate::platform::HwBackend;
 
@@ -56,7 +53,7 @@ fn resolution_ladder(target: u32) -> &'static [u32] {
     }
 }
 
-/// Append a `bv*[…]` arm and (when not video-only) the matching `b[…]` arm.
+/// Appends a video-containing selection arm and optional combined-format fallback.
 fn push_pair(comps: &mut Vec<String>, video_only: bool, body: &str) {
     comps.push(format!("bv*{body}"));
     if !video_only {
@@ -71,8 +68,7 @@ pub fn build_format(p: &FormatParams) -> String {
     let max_h = max_height_for(p.height);
     let ladder = resolution_ladder(p.height);
     let resolutions: Vec<u32> = ladder.iter().copied().filter(|r| *r <= max_h).collect();
-    // Tiny targets can fully filter the ladder; fall back to one tier so the
-    // selector always has at least one resolution-pinned arm.
+    // Preserve one resolution tier when the target cap excludes the entire ladder.
     let resolutions = if resolutions.is_empty() {
         vec![240]
     } else {
@@ -82,8 +78,7 @@ pub fn build_format(p: &FormatParams) -> String {
     let mut comps: Vec<String> = Vec::new();
 
     if p.prefer_60fps {
-        // 60fps streams only exist at ≥720p on YouTube — pin to 720 regardless
-        // of the target height.
+        // Prefer 720p/60fps before resolution tiers, even for small targets.
         for codec in codecs {
             push_pair(
                 &mut comps,
@@ -129,8 +124,7 @@ pub fn build_format(p: &FormatParams) -> String {
         comps.push("b[protocol=https]".to_string());
     }
 
-    // Final any-protocol fallbacks — for live streams and DASH/HLS edge cases
-    // where no https progressive format exists.
+    // Live and segmented streams can lack a progressive HTTPS format.
     comps.push("bv*".to_string());
     if !p.video_only {
         comps.push("b".to_string());

--- a/src/yt_dlp/mod.rs
+++ b/src/yt_dlp/mod.rs
@@ -1,18 +1,6 @@
-//! yt-dlp integration: pure helpers (format selector, output parsing) plus
-//! the subprocess driver. Decoupled from the `Resolver` trait so anything in
-//! the codebase can shell out to yt-dlp without going through the resolver
-//! layer.
-//!
-//! Distribution assumption: `yt-dlp` and (for YouTube) `deno` are on `PATH`.
-//! Recommended install:
-//!
-//! ```text
-//! uv tool install 'yt-dlp[default,curl-cffi]'   # bundles yt-dlp-ejs
-//! ```
-//!
-//! `[default]` includes `yt-dlp-ejs` which carries the JS bundle Deno
-//! executes for YouTube's signature/n-sig challenges. Without it, YouTube
-//! resolution fails. Other extractors don't need Deno.
+//! Runs yt-dlp extraction with format selection, output parsing, and cancellation.
+//! yt-dlp and the optional Deno runtime are discovered on PATH; YouTube challenge
+//! solving requires a supported runtime and the yt-dlp-ejs package.
 
 pub mod format;
 pub mod output;
@@ -31,8 +19,7 @@ pub struct YtDlp {
     deno: Option<PathBuf>,
 }
 
-/// Extraction can launch Deno workers. Killing only yt-dlp leaves those
-/// workers running after a timeout or stream cancellation.
+/// Kills the extraction process group on cancellation, including Deno workers.
 #[cfg(unix)]
 struct ProcessGroupGuard(Option<rustix::process::Pid>);
 
@@ -53,8 +40,7 @@ pub enum YtDlpError {
     #[error("yt-dlp spawn failed: {0}")]
     Spawn(#[from] std::io::Error),
 
-    /// yt-dlp exited non-zero. `message` is the last `ERROR:` line scraped
-    /// from stderr, or a generic failure message if none was found.
+    /// Nonzero exit with the last `ERROR:` line, remaining stderr, or a fallback message.
     #[error("yt-dlp failed: {message}")]
     Failed { message: String, exit_code: Option<i32> },
 
@@ -63,10 +49,7 @@ pub enum YtDlpError {
 }
 
 impl YtDlp {
-    /// Look up `yt-dlp` and `deno` on `PATH`. Returns `None` if `yt-dlp` is
-    /// missing — the caller decides whether that's fatal. A missing `deno`
-    /// is not fatal here; only YouTube extraction fails without it, and we
-    /// surface that as a runtime error per-resolution.
+    /// Discovers yt-dlp and Deno on PATH. Returns `None` only when yt-dlp is missing.
     pub fn detect() -> Option<Self> {
         let bin = which::which("yt-dlp").ok()?;
         let deno = which::which("deno").ok();
@@ -132,8 +115,7 @@ impl YtDlp {
                 return Err(YtDlpError::Timeout);
             }
         };
-        // The child and its output pipes completed normally. No cancellation
-        // cleanup remains, and the process group ID can now be reused.
+        // Completed output needs no cancellation cleanup; avoid signaling a reused group ID.
         #[cfg(unix)]
         {
             process_group.0 = None;
@@ -153,9 +135,7 @@ impl YtDlp {
                 .rfind(|l| l.starts_with("ERROR:"))
                 .map(str::to_string)
                 .unwrap_or_else(|| {
-                    // No `ERROR:` line — surface whatever stderr we got so the
-                    // failure isn't opaque (argparse errors, deno crashes,
-                    // proxy/CA issues all land here).
+                    // Preserve stderr for failures without yt-dlp's ERROR prefix.
                     let trimmed = stderr.trim();
                     if trimmed.is_empty() {
                         "yt-dlp exited non-zero (no stderr)".to_string()

--- a/src/yt_dlp/output.rs
+++ b/src/yt_dlp/output.rs
@@ -1,24 +1,18 @@
-//! Parsing helpers for `yt-dlp -j` stdout. The shape of `Info` is the
-//! intersection we actually consume, not yt-dlp's full info-dict schema.
-//! `serde(default)` everywhere because extractors are inconsistent about
-//! which fields they populate (e.g. live streams skip `filesize`).
+//! Parses the yt-dlp fields consumed by resolution. Optional fields accommodate
+//! extractors that omit metadata such as frame rate or file size.
 
 use std::collections::HashMap;
 
 use serde::Deserialize;
 
-/// Subset of yt-dlp's info-dict that we use. yt-dlp emits dozens of fields;
-/// we only deserialize the ones the resolver consumes.
+/// Extraction metadata consumed by the resolver.
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct Info {
-    /// The selected stream URL. Populated when `-f` picks a single format
-    /// (i.e. no `+` merge). For merged selections the URL lives in
-    /// `requested_formats[*].url` instead — we don't support that here.
+    /// Selected format URL. Merged `requested_formats` output is unsupported.
     #[serde(default)]
     pub url: Option<String>,
 
-    /// Per-stream HTTP headers (User-Agent, Accept-Language, etc.) that the
-    /// CDN expects. Forwarded into ffmpeg's `-headers` option verbatim.
+    /// Upstream HTTP headers; dispatch rejects entries containing control characters.
     #[serde(default)]
     pub http_headers: Option<HashMap<String, String>>,
 
@@ -32,17 +26,13 @@ pub struct Info {
     #[serde(default)]
     pub filesize: Option<u64>,
 
-    /// yt-dlp's range-derived size estimate when the exact size isn't known
-    /// up front. Use as a fallback when `filesize` is absent.
+    /// Estimated size in bytes, used when `filesize` is absent.
     #[serde(default)]
     pub filesize_approx: Option<u64>,
 }
 
-/// Extract the unix-second expiry timestamp from a googlevideo CDN URL.
-///
-/// YouTube stream URLs include `?expire=<unix-seconds>`. Returns `None` for
-/// any URL that doesn't carry the parameter (non-YouTube extractors,
-/// non-googlevideo hosts, malformed URLs).
+/// Returns an integer `expire` query parameter in Unix seconds, regardless of host.
+/// Missing or malformed values return `None`.
 pub fn parse_googlevideo_expire(url: &str) -> Option<i64> {
     url.split_once('?')?
         .1
@@ -90,7 +80,6 @@ mod tests {
 
     #[test]
     fn info_deserializes_minimal_yt_dlp_output() {
-        // Minimum yt-dlp -j output for a non-YouTube extractor.
         let json = r#"{"url": "https://cdn.example/v.mp4", "vcodec": "h264"}"#;
         let info: Info = serde_json::from_str(json).expect("parse");
         assert_eq!(info.url.as_deref(), Some("https://cdn.example/v.mp4"));
@@ -117,7 +106,6 @@ mod tests {
 
     #[test]
     fn info_tolerates_unknown_fields() {
-        // yt-dlp's info-dict is huge; we should ignore everything we don't ask for.
         let json = r#"{
             "url": "x",
             "title": "ignored",

--- a/tests/animated_disposal.rs
+++ b/tests/animated_disposal.rs
@@ -122,8 +122,7 @@ fn check_fixture(name: &str) {
             .zip(bytes.as_chunks::<4>().0.iter())
             .enumerate()
         {
-            // Transparent RGB is undefined. Allow one rounding unit
-            // for integer alpha compositors; never tolerate ghost pixels.
+            // RGB beneath zero alpha is undefined; integer alpha rounding permits one unit.
             assert!(
                 actual[3].abs_diff(expected[3]) <= 1,
                 "{name} frame {index} pixel {pixel}: {actual:?} != {expected:?}"

--- a/tests/smoke.py
+++ b/tests/smoke.py
@@ -184,9 +184,7 @@ def run(binary):
                         assert response['type'] == 'ack', response
                         for _ in range(3):
                             assert udp.recv(65535)[10:] == b'\0\0\xff' * 256
-                        # Exercise retained default media paths, including decoder
-                        # formats previously missed by unit coverage. Omit loop,
-                        # fit, fmt, pace, ema, expand and hw as ddp-esphome does.
+                        # Omit playback overrides to exercise the defaults used by ddp-esphome.
                         sources = [str(root / name) for name in ['red.png', 'wide.png', 'anim.gif', 'anim.png', 'anim.webp', 'clip.mp4']]
                         sources += [media_url + '/stream']
                         if shutil.which('yt-dlp'):


### PR DESCRIPTION
Describe the server's current behavior in setup instructions, API/configuration references, and source comments. The README links to focused reference pages; release archives include those pages. Code comments retain timing, ownership, format and workaround constraints while removing implementation narration and migration history.

Correct factual claims about DDP IP addresses/output IDs, FFmpeg range conversion, packet redundancy, image filters/ICC support, font metrics, and protocol responses. Add-on setup and publishing documentation is updated in stuartparmenter/media-proxy-addon#35. Changelogs, required notices, fixture references retain their purpose.

Follows the [technical-writing skill and references](https://github.com/pavlov-net/claude-plugins/tree/main/tech-writing/skills/technical-writing). Independent review checked the reference pages against the code. Lexical/AST comparisons confirm unchanged Rust/Python executable content apart from two help/error text strings; Cargo's repository URL also points to the canonical repository.

Validation: strict Rustdoc, formatting, local Markdown links, 161 unit tests plus the GIF/APNG disposal integration test (three upstream WebP cases explicitly ignored), actionlint, Clippy, and real-binary streaming smoke pass. Both architecture packages and lint passed GitHub CI before the dependency simplification; updated checks are pending. The runtime fixes are in #144 and release workflow changes in #145; this PR is stacked on #145.
